### PR TITLE
Graph View + Proper Markdown Rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,12 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -318,6 +324,7 @@ dependencies = [
  "fuzzy-matcher",
  "image",
  "once_cell",
+ "portable-pty",
  "rand 0.8.5",
  "ratatui",
  "serde",
@@ -326,6 +333,7 @@ dependencies = [
  "tempfile",
  "toml",
  "trash",
+ "tui-term",
  "tui-textarea",
  "uuid",
  "which",
@@ -425,7 +433,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -522,9 +530,15 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -622,6 +636,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -886,6 +911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +962,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -1038,6 +1078,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1123,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
 
 [[package]]
 name = "nom"
@@ -1155,7 +1218,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -1167,7 +1230,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
 ]
@@ -1178,7 +1241,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1197,7 +1260,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1208,7 +1271,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1273,12 +1336,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1294,6 +1363,27 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
 ]
 
 [[package]]
@@ -1450,7 +1540,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1541,7 +1631,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1567,7 +1657,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1580,7 +1670,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1677,6 +1767,64 @@ dependencies = [
  "serde",
  "version_check",
 ]
+
+[[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1807,6 +1955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-term"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72af159125ce32b02ceaced6cffae6394b0e6b6dfd4dc164a6c59a2db9b3c0b0"
+dependencies = [
+ "ratatui",
+ "vt100",
+]
+
+[[package]]
 name = "tui-textarea"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +2176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2214,39 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vt100"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cd863bf0db7e392ba3bd04994be3473491b31e66340672af5d11943c6274de"
+dependencies = [
+ "itoa",
+ "log",
+ "unicode-width 0.1.14",
+ "vte",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "wasi"
@@ -2139,7 +2345,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2452,6 +2658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,7 +2724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,12 +342,14 @@ dependencies = [
  "chrono",
  "crossterm",
  "directories",
+ "fdg-sim",
  "fuzzy-matcher",
  "image",
  "once_cell",
  "portable-pty",
  "rand 0.8.5",
  "ratatui",
+ "regex",
  "serde",
  "serde_json",
  "serde_yml",
@@ -639,6 +662,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdg-sim"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2417e237094dfd115a4aa11b2a3dc6cda45e8d36572a7862ba9a48402f7441a3"
+dependencies = [
+ "glam",
+ "hashlink",
+ "petgraph",
+ "quad-rand",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +689,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -747,6 +788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +802,16 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -773,6 +830,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1336,6 +1402,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1523,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-error"
@@ -1644,6 +1726,35 @@ dependencies = [
  "libredox",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rgb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ directories = "5.0"
 fuzzy-matcher = "0.3.7"
 image = "0.25.10"
 once_cell = "1.21.4"
+portable-pty = "0.8"
 rand = "0.8"
 ratatui = "0.29"
 serde = { version = "1.0", features = ["derive"] }
@@ -56,6 +57,7 @@ serde_yml = "0.0.12"
 tempfile = "3.27.0"
 toml = "0.8"
 trash = "5"
+tui-term = "0.2"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 uuid = { version = "1.8", features = ["v4"] }
 which = "8.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clin-rs"
-version = "0.3.6"
+version = "0.4.2"
 edition = "2024"
 description = "Encrypted terminal note-taking app"
 authors = ["reekta92 mdag.92988@protonmail.com"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,8 @@ crossterm = "0.28"
 directories = "5.0"
 fuzzy-matcher = "0.3.7"
 image = "0.25.10"
-once_cell = "1.21.4"
-portable-pty = "0.8"
-rand = "0.8"
+ once_cell = "1.21.4"
+ rand = "0.8"
 ratatui = "0.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -64,6 +63,7 @@ fdg-sim = "0.9"
 regex = "1"
 which = "8.0.2"
 zeroize = { version = "1.8.2", features = ["derive"] }
+portable-pty = "0.8"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ trash = "5"
 tui-term = "0.2"
 tui-textarea = { version = "0.7", features = ["crossterm"] }
 uuid = { version = "1.8", features = ["v4"] }
+fdg-sim = "0.9"
+regex = "1"
 which = "8.0.2"
 zeroize = { version = "1.8.2", features = ["derive"] }
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ This file is generated automatically. You can edit it to change your settings:
 storage_path = "/custom/path/to/vault" # Optional: Change where notes are stored
 external_editor = "nvim" # Optional: Command to use for the external editor
 external_editor_enabled = false
-encryption_enabled = true # Whether new notes should be encrypted by default
 ```
 
 ### Custom Keybinds (`keybinds.toml`)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 -  Unicode glyphs, **requires a Nerd Font**
 -  **ChaCha20-Poly1305** encryption (optional)
 -  Binary `.clin` files
--  Full-screen TUI with list + editor + help views  
+-  Full-screen TUI with list + editor + help + graph views
 -  Mouse support + bracketed paste  
 -  **Folders & Tags**  
 -  **Continuous Auto-save** (with panic crash safety logic)
@@ -70,7 +70,7 @@
 * [ ] **Backlinks:** Related to **Linking notes**, allow for following backlinks. Using indexing caching.
 * [ ] **Forwardlinks:** Related to **Linking notes**, allow for following forward links.
 * [ ] **Sub-notes:** Orphan notes, creating virtual sub-notes that are attached to a note without physically existing on the disk. Using **backlinks**.
-* [ ] **Graph View:** Visual graph of linked notes, related to **Linking notes**.
+* [x] **Graph View:** Visual graph of linked notes, related to **Linking notes**. Force-directed layout with `[[wikilinks]]`, pan/zoom, click-to-open.
 * [ ] **Insert Date/Time:** Insert date/time.
 * [ ] **Calculator:** Simple calculator, inserts the simple mathematical calculations result.
 * [ ] **Calendar Picker:** Calendar UI to pick and insert a specific date.

--- a/src/actions/decrypt.rs
+++ b/src/actions/decrypt.rs
@@ -1,0 +1,52 @@
+use super::Action;
+use crate::app::App;
+use anyhow::{Result, anyhow};
+use std::borrow::Cow;
+
+pub struct DecryptNoteAction;
+
+impl Action for DecryptNoteAction {
+    fn id(&self) -> Cow<'static, str> {
+        Cow::Borrowed("note.decrypt")
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Decrypt Note")
+    }
+
+    fn description(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Decrypt the selected note (.clin \u{2192} .md)")
+    }
+
+    fn execute(&self, app: &mut App, context_note_id: Option<&str>) -> Result<()> {
+        let note_id = context_note_id
+            .map(|s| s.to_string())
+            .or_else(|| {
+                app.visual_list
+                    .get(app.visual_index)
+                    .and_then(|item| match item {
+                        crate::app::VisualItem::Note { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+            })
+            .ok_or_else(|| anyhow!("No note selected"))?;
+
+        if !note_id.ends_with(".clin") {
+            app.set_temporary_status_static("Note is not encrypted");
+            return Ok(());
+        }
+
+        match app.storage.decrypt_note(&note_id) {
+            Ok(new_id) => {
+                app.folder_cache = None;
+                let _ = app.refresh_notes();
+                app.set_temporary_status(&format!("Note decrypted: {}", new_id));
+            }
+            Err(e) => {
+                app.set_temporary_status(&format!("Failed to decrypt: {e:#}"));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/actions/encrypt.rs
+++ b/src/actions/encrypt.rs
@@ -1,0 +1,52 @@
+use super::Action;
+use crate::app::App;
+use anyhow::{Result, anyhow};
+use std::borrow::Cow;
+
+pub struct EncryptNoteAction;
+
+impl Action for EncryptNoteAction {
+    fn id(&self) -> Cow<'static, str> {
+        Cow::Borrowed("note.encrypt")
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Encrypt Note")
+    }
+
+    fn description(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Encrypt the selected note (.md \u{2192} .clin)")
+    }
+
+    fn execute(&self, app: &mut App, context_note_id: Option<&str>) -> Result<()> {
+        let note_id = context_note_id
+            .map(|s| s.to_string())
+            .or_else(|| {
+                app.visual_list
+                    .get(app.visual_index)
+                    .and_then(|item| match item {
+                        crate::app::VisualItem::Note { id, .. } => Some(id.clone()),
+                        _ => None,
+                    })
+            })
+            .ok_or_else(|| anyhow!("No note selected"))?;
+
+        if note_id.ends_with(".clin") {
+            app.set_temporary_status_static("Note is already encrypted");
+            return Ok(());
+        }
+
+        match app.storage.encrypt_note(&note_id) {
+            Ok(new_id) => {
+                app.folder_cache = None;
+                let _ = app.refresh_notes();
+                app.set_temporary_status(&format!("Note encrypted: {}", new_id));
+            }
+            Err(e) => {
+                app.set_temporary_status(&format!("Failed to encrypt: {e:#}"));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/actions/graph.rs
+++ b/src/actions/graph.rs
@@ -1,0 +1,25 @@
+use super::Action;
+use crate::app::App;
+use anyhow::Result;
+use std::borrow::Cow;
+
+pub struct OpenGraphAction;
+
+impl Action for OpenGraphAction {
+    fn id(&self) -> Cow<'static, str> {
+        Cow::Borrowed("graph.open")
+    }
+
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Open Graph View")
+    }
+
+    fn description(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Visualize note connections as a force-directed graph")
+    }
+
+    fn execute(&self, app: &mut App, _context_note_id: Option<&str>) -> Result<()> {
+        app.open_graph_view();
+        Ok(())
+    }
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,3 +1,5 @@
+pub mod decrypt;
+pub mod encrypt;
 pub mod ocr;
 
 use crate::app::App;
@@ -18,7 +20,13 @@ pub struct ActionInfo {
     pub description: String,
 }
 
-pub static ACTIONS: Lazy<Vec<Box<dyn Action>>> = Lazy::new(|| vec![Box::new(ocr::OcrPasteAction)]);
+pub static ACTIONS: Lazy<Vec<Box<dyn Action>>> = Lazy::new(|| {
+    vec![
+        Box::new(encrypt::EncryptNoteAction),
+        Box::new(decrypt::DecryptNoteAction),
+        Box::new(ocr::OcrPasteAction),
+    ]
+});
 
 pub static ACTION_INFOS: Lazy<Vec<ActionInfo>> = Lazy::new(|| {
     ACTIONS

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,5 +1,6 @@
 pub mod decrypt;
 pub mod encrypt;
+pub mod graph;
 pub mod ocr;
 
 use crate::app::App;
@@ -24,6 +25,7 @@ pub static ACTIONS: Lazy<Vec<Box<dyn Action>>> = Lazy::new(|| {
     vec![
         Box::new(encrypt::EncryptNoteAction),
         Box::new(decrypt::DecryptNoteAction),
+        Box::new(graph::OpenGraphAction),
         Box::new(ocr::OcrPasteAction),
     ]
 });

--- a/src/actions/ocr.rs
+++ b/src/actions/ocr.rs
@@ -137,8 +137,7 @@ impl Action for OcrPasteAction {
         note.content.push_str(&extracted_text);
         note.updated_at = crate::ui::now_unix_secs();
 
-        let is_clin = note_id.ends_with(".clin");
-        app.storage.save_note(note_id, &note, is_clin)?;
+        app.storage.save_note(note_id, &note)?;
         app.refresh_notes()?;
         app.set_temporary_status("OCR text appended successfully");
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use crate::events::make_title_editor;
 use crate::ui::help_page_text;
 use crate::ui::text_area_from_content;
 use crate::ui::{now_unix_secs, open_in_file_manager};
+use crate::markdown::MarkdownRenderer;
 use ratatui::style::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
@@ -200,7 +201,9 @@ pub struct App {
     pub sort_order: SortOrder,
     pub trash_view: Option<TrashView>,
     pub preview_enabled: bool,
-    pub preview_content: Option<String>,
+    pub preview_renderer: Option<MarkdownRenderer>,
+    pub markdown_preview_enabled: bool,
+    pub md_preview_renderer: Option<MarkdownRenderer>,
     /// For vim-style 'gg' command - tracks last 'g' press time
     pub last_g_press: Option<Instant>,
     /// Page size for Ctrl+u/d navigation
@@ -281,7 +284,9 @@ impl App {
             sort_order: SortOrder::Descending,
             trash_view: None,
             preview_enabled: bootstrap_config.preview_enabled,
-            preview_content: None,
+            preview_renderer: None,
+            markdown_preview_enabled: bootstrap_config.markdown_preview_enabled,
+            md_preview_renderer: None,
             last_g_press: None,
             page_size: 10,
         };
@@ -1049,6 +1054,7 @@ impl App {
         self.title_editor = make_title_editor("");
         self.editor = TextArea::default();
         self.confirm_popup = None;
+        self.md_preview_renderer = None;
         let _ = self.refresh_notes();
         self.set_default_status();
     }
@@ -2195,9 +2201,28 @@ impl App {
             self.update_preview();
             self.set_temporary_status_static("Preview enabled");
         } else {
-            self.preview_content = None;
+            self.preview_renderer = None;
             self.set_temporary_status_static("Preview disabled");
         }
+        if let Ok(mut config) = crate::config::BootstrapConfig::load() {
+            config.preview_enabled = self.preview_enabled;
+            let _ = config.save();
+        }
+    }
+
+    pub fn poll_renderers(&mut self) -> bool {
+        let mut updated = false;
+        if let Some(renderer) = &mut self.preview_renderer {
+            if renderer.poll() {
+                updated = true;
+            }
+        }
+        if let Some(renderer) = &mut self.md_preview_renderer {
+            if renderer.poll() {
+                updated = true;
+            }
+        }
+        updated
     }
 
     /// Update preview content for currently selected note
@@ -2208,14 +2233,42 @@ impl App {
 
         if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned() {
             if let Ok(note) = self.storage.load_note(&id) {
-                // Truncate to first 50 lines for preview
-                let preview: String = note.content.lines().take(50).collect::<Vec<_>>().join("\n");
-                self.preview_content = Some(preview);
+                let width = 80u16.saturating_sub(2).max(40);
+                let mut renderer = MarkdownRenderer::new(width);
+                renderer.render(&note.content, width);
+                self.preview_renderer = Some(renderer);
             } else {
-                self.preview_content = None;
+                self.preview_renderer = None;
             }
         } else {
-            self.preview_content = None;
+            self.preview_renderer = None;
+        }
+    }
+
+    pub fn update_editor_markdown_preview(&mut self) {
+        if !self.markdown_preview_enabled {
+            return;
+        }
+
+        let content = self.editor.lines().join("\n");
+        let width = 80u16.saturating_sub(2).max(40);
+        let mut renderer = MarkdownRenderer::new(width);
+        renderer.render(&content, width);
+        self.md_preview_renderer = Some(renderer);
+    }
+
+    pub fn toggle_markdown_preview(&mut self) {
+        self.markdown_preview_enabled = !self.markdown_preview_enabled;
+        if self.markdown_preview_enabled {
+            self.update_editor_markdown_preview();
+            self.set_temporary_status_static("Markdown preview enabled");
+        } else {
+            self.md_preview_renderer = None;
+            self.set_temporary_status_static("Markdown preview disabled");
+        }
+        if let Ok(mut config) = crate::config::BootstrapConfig::load() {
+            config.markdown_preview_enabled = self.markdown_preview_enabled;
+            let _ = config.save();
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub enum ViewMode {
     List,
     Edit,
     Help,
+    Graph,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,8 +206,11 @@ pub struct App {
     pub md_preview_renderer: Option<MarkdownRenderer>,
     /// For vim-style 'gg' command - tracks last 'g' press time
     pub last_g_press: Option<Instant>,
-    /// Page size for Ctrl+u/d navigation
     pub page_size: usize,
+    pub graph_state: Option<std::sync::Arc<std::sync::RwLock<crate::graph::GraphState>>>,
+    pub graph_kill_tx: Option<std::sync::mpsc::Sender<()>>,
+    pub return_mode: Option<ViewMode>,
+    pub graph_mouse_state: crate::graph::input::GraphMouseState,
 }
 
 pub enum CliCommand {
@@ -287,6 +291,10 @@ impl App {
             md_preview_renderer: None,
             last_g_press: None,
             page_size: 10,
+            graph_state: None,
+            graph_kill_tx: None,
+            return_mode: None,
+            graph_mouse_state: crate::graph::input::GraphMouseState::default(),
         };
         app.context_menu = None;
         app.template_popup = None;
@@ -1046,6 +1054,16 @@ impl App {
     }
 
     pub fn back_to_list(&mut self) {
+        if let Some(return_to) = self.return_mode.take() {
+            self.editing_id = None;
+            self.title_editor = make_title_editor("");
+            self.editor = TextArea::default();
+            self.confirm_popup = None;
+            self.md_preview_renderer = None;
+            self.mode = return_to;
+            self.set_default_status();
+            return;
+        }
         self.mode = ViewMode::List;
         self.editing_id = None;
         self.list_focus = ListFocus::Notes;
@@ -1778,11 +1796,74 @@ impl App {
         self.set_default_status();
     }
 
+    pub fn open_graph_view(&mut self) {
+        let graph = match crate::graph::build_graph(&self.storage) {
+            Ok(g) => g,
+            Err(e) => {
+                self.set_temporary_status(&format!("Failed to build graph: {e}"));
+                return;
+            }
+        };
+
+        if graph.node_count() == 0 {
+            self.set_temporary_status_static("No notes found for graph view");
+            return;
+        }
+
+        let simulation = crate::graph::create_simulation(graph);
+        let mut state = crate::graph::GraphState {
+            viewport: crate::graph::viewport::Viewport::default(),
+            simulation,
+            selected_node: None,
+            dragging_node: None,
+            is_settled: false,
+            show_labels: true,
+        };
+        let vp = state
+            .viewport
+            .auto_fit_from_graph(state.simulation.get_graph());
+        state.viewport = vp;
+
+        let state = std::sync::Arc::new(std::sync::RwLock::new(state));
+        let (kill_tx, kill_rx) = std::sync::mpsc::channel();
+        crate::graph::physics::start_physics(state.clone(), kill_rx);
+
+        self.graph_state = Some(state);
+        self.graph_kill_tx = Some(kill_tx);
+        self.graph_mouse_state = crate::graph::input::GraphMouseState::default();
+        self.mode = ViewMode::Graph;
+        self.return_mode = None;
+        self.set_default_status();
+    }
+
+    pub fn close_graph_view(&mut self) {
+        if let Some(tx) = self.graph_kill_tx.take() {
+            let _ = tx.send(());
+        }
+        self.graph_state = None;
+        self.mode = ViewMode::List;
+        self.set_default_status();
+    }
+
+    pub fn open_note_from_graph(&mut self, note_id: &str) {
+        if note_id.ends_with(".clin") {
+            self.set_temporary_status_static("Cannot open encrypted notes. Decrypt first.");
+            return;
+        }
+        self.return_mode = Some(ViewMode::Graph);
+        if self.external_editor_enabled {
+            self.open_note_in_external_editor(note_id);
+        } else {
+            self.load_and_open_note(note_id);
+        }
+    }
+
     pub fn default_status_text(&self) -> &'static str {
         match self.mode {
             ViewMode::List => LIST_HELP_HINTS,
             ViewMode::Edit => EDIT_HELP_HINTS,
             ViewMode::Help => HELP_PAGE_HINTS,
+            ViewMode::Graph => "Graph View | Esc: back | +/-: zoom | L: labels | a: fit",
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,10 @@
 use crate::constants::*;
 use crate::events::get_title_text;
 use crate::events::make_title_editor;
+use crate::markdown::MarkdownRenderer;
 use crate::ui::help_page_text;
 use crate::ui::text_area_from_content;
 use crate::ui::{now_unix_secs, open_in_file_manager};
-use crate::markdown::MarkdownRenderer;
 use ratatui::style::{Color, Style};
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
@@ -16,7 +16,9 @@ use crate::keybinds::Keybinds;
 use crate::storage::{Note, NoteSummary, Storage};
 use crate::templates::{Template, TemplateSummary};
 use anyhow::Result;
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tui_textarea::TextArea;
@@ -31,14 +33,12 @@ pub enum ViewMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ListFocus {
     Notes,
-    EncryptionToggle,
     ExternalEditorToggle,
 }
 
 pub enum ConfirmAction {
     DeleteNote { note_id: String, title: String },
     DeleteFolder { path: String },
-    EncryptNote { note_id: String },
     DeleteTag { tag: String },
     DeleteFromTrash { item: trash::TrashItem },
     EmptyTrash { items: Vec<trash::TrashItem> },
@@ -172,7 +172,6 @@ pub struct App {
     pub editing_id: Option<String>,
     pub title_editor: TextArea<'static>,
     pub editor: TextArea<'static>,
-    pub encryption_enabled: bool,
     pub external_editor_enabled: bool,
     pub external_editor: Option<String>,
     pub status: Cow<'static, str>,
@@ -256,7 +255,6 @@ impl App {
             editing_id: None,
             title_editor: make_title_editor(""),
             editor: TextArea::default(),
-            encryption_enabled: bootstrap_config.encryption_enabled,
             external_editor_enabled: bootstrap_config.external_editor_enabled,
             external_editor: bootstrap_config.external_editor,
             status: Cow::Borrowed(LIST_HELP_HINTS),
@@ -317,7 +315,7 @@ impl App {
                 summaries.push(summary);
             }
         }
-        
+
         // Sort based on current sort options
         // Pinned notes always come first, then apply user's sort preference
         summaries.sort_by(|a, b| {
@@ -326,7 +324,7 @@ impl App {
             if pin_cmp != std::cmp::Ordering::Equal {
                 return pin_cmp;
             }
-            
+
             // Then encrypted notes (for backwards compat)
             let a_clin = a.id.ends_with(".clin");
             let b_clin = b.id.ends_with(".clin");
@@ -334,21 +332,17 @@ impl App {
             if clin_cmp != std::cmp::Ordering::Equal {
                 return clin_cmp;
             }
-            
+
             // Then apply user's sort preference
             match self.sort_field {
-                SortField::Modified => {
-                    match self.sort_order {
-                        SortOrder::Descending => b.updated_at.cmp(&a.updated_at),
-                        SortOrder::Ascending => a.updated_at.cmp(&b.updated_at),
-                    }
-                }
-                SortField::Title => {
-                    match self.sort_order {
-                        SortOrder::Ascending => a.title.to_lowercase().cmp(&b.title.to_lowercase()),
-                        SortOrder::Descending => b.title.to_lowercase().cmp(&a.title.to_lowercase()),
-                    }
-                }
+                SortField::Modified => match self.sort_order {
+                    SortOrder::Descending => b.updated_at.cmp(&a.updated_at),
+                    SortOrder::Ascending => a.updated_at.cmp(&b.updated_at),
+                },
+                SortField::Title => match self.sort_order {
+                    SortOrder::Ascending => a.title.to_lowercase().cmp(&b.title.to_lowercase()),
+                    SortOrder::Descending => b.title.to_lowercase().cmp(&a.title.to_lowercase()),
+                },
             }
         });
 
@@ -435,66 +429,66 @@ impl App {
 
         for folder in all_folders {
             let parts: Vec<&str> = folder.split('/').collect();
-                let depth = parts.len();
-                let name = parts.last().unwrap_or(&"").to_string();
+            let depth = parts.len();
+            let name = parts.last().unwrap_or(&"").to_string();
 
-                // Only show if parent is expanded
-                let parent_path = if parts.len() > 1 {
-                    parts[..parts.len() - 1].join("/")
-                } else {
-                    String::new()
-                };
+            // Only show if parent is expanded
+            let parent_path = if parts.len() > 1 {
+                parts[..parts.len() - 1].join("/")
+            } else {
+                String::new()
+            };
 
-                // Fast check if parent is expanded
-                let mut is_visible = true;
-                let mut current_parent = parent_path.clone();
-                while !current_parent.is_empty() {
-                    if !self.folder_expanded.contains(&current_parent) {
-                        is_visible = false;
-                        break;
-                    }
-                    if let Some(slash) = current_parent.rfind('/') {
-                        current_parent = current_parent[..slash].to_string();
-                    } else {
-                        current_parent = String::new();
-                    }
-                }
-
-                // Finally check root
-                if !self.folder_expanded.contains("") {
+            // Fast check if parent is expanded
+            let mut is_visible = true;
+            let mut current_parent = parent_path.clone();
+            while !current_parent.is_empty() {
+                if !self.folder_expanded.contains(&current_parent) {
                     is_visible = false;
+                    break;
                 }
-
-                if is_visible {
-                    let is_expanded = self.folder_expanded.contains(&folder);
-                    visual.push(VisualItem::Folder {
-                        path: folder.clone(),
-                        name,
-                        depth,
-                        is_expanded,
-                        note_count: by_folder
-                            .get(&folder)
-                            .map_or(0, |v: &Vec<(usize, &NoteSummary)>| v.len()),
-                    });
-
-                    if is_expanded {
-                        if let Some(notes) = by_folder.get(&folder) {
-                            for (idx, note) in notes {
-                                visual.push(VisualItem::Note {
-                                    id: note.id.clone(),
-                                    summary_idx: *idx,
-                                    depth: depth + 1,
-                                    is_clin: note.id.ends_with(".clin"),
-                                });
-                            }
-                        }
-                        visual.push(VisualItem::CreateNew {
-                            path: folder.clone(),
-                            depth: depth + 1,
-                        });
-                    }
+                if let Some(slash) = current_parent.rfind('/') {
+                    current_parent = current_parent[..slash].to_string();
+                } else {
+                    current_parent = String::new();
                 }
             }
+
+            // Finally check root
+            if !self.folder_expanded.contains("") {
+                is_visible = false;
+            }
+
+            if is_visible {
+                let is_expanded = self.folder_expanded.contains(&folder);
+                visual.push(VisualItem::Folder {
+                    path: folder.clone(),
+                    name,
+                    depth,
+                    is_expanded,
+                    note_count: by_folder
+                        .get(&folder)
+                        .map_or(0, |v: &Vec<(usize, &NoteSummary)>| v.len()),
+                });
+
+                if is_expanded {
+                    if let Some(notes) = by_folder.get(&folder) {
+                        for (idx, note) in notes {
+                            visual.push(VisualItem::Note {
+                                id: note.id.clone(),
+                                summary_idx: *idx,
+                                depth: depth + 1,
+                                is_clin: note.id.ends_with(".clin"),
+                            });
+                        }
+                    }
+                    visual.push(VisualItem::CreateNew {
+                        path: folder.clone(),
+                        depth: depth + 1,
+                    });
+                }
+            }
+        }
 
         self.visual_list = visual;
     }
@@ -543,17 +537,10 @@ impl App {
             VisualItem::Note { summary_idx, .. } => {
                 let note_id = if let Some(summary) = self.notes.get(*summary_idx) {
                     let is_clin = summary.id.ends_with(".clin");
-                    if !self.encryption_enabled && is_clin {
+                    if is_clin {
                         self.status = Cow::Borrowed(
-                            "Cannot open encrypted notes while encryption is disabled.",
+                            "Note is encrypted. Use command palette (Ctrl+P) to decrypt.",
                         );
-                        return;
-                    }
-
-                    if self.encryption_enabled && !is_clin {
-                        self.show_confirm(ConfirmAction::EncryptNote {
-                            note_id: summary.id.clone(),
-                        });
                         return;
                     }
                     Some(summary.id.clone())
@@ -631,13 +618,16 @@ impl App {
                 crossterm::event::DisableBracketedPaste
             );
 
-            let editor = self.external_editor.clone()
+            let editor = self
+                .external_editor
+                .clone()
                 .or_else(|| std::env::var("VISUAL").ok())
                 .or_else(|| std::env::var("EDITOR").ok())
                 .unwrap_or_else(|| "vi".to_string());
 
             let parts: Vec<&str> = editor.split_whitespace().collect();
-            let (program, editor_args) = parts.split_first()
+            let (program, editor_args) = parts
+                .split_first()
                 .map(|(p, a)| (*p, a.to_vec()))
                 .unwrap_or(("vi", vec![]));
 
@@ -669,12 +659,14 @@ impl App {
                                 updated_at: now_unix_secs(),
                                 tags: note.tags,
                             };
-                            if let Err(e) = self.storage.save_note(note_id, &updated_note, self.encryption_enabled) {
+                            if let Err(e) = self.storage.save_note(note_id, &updated_note) {
                                 self.set_temporary_status(&format!("Failed to save note: {}", e));
                             } else {
-                                self.set_temporary_status_static("Note saved from external editor.");
-                        self.folder_cache = None;
-                        let _ = self.refresh_notes();
+                                self.set_temporary_status_static(
+                                    "Note saved from external editor.",
+                                );
+                                self.folder_cache = None;
+                                let _ = self.refresh_notes();
                             }
                         } else {
                             self.set_temporary_status_static("No changes made in external editor.");
@@ -684,10 +676,16 @@ impl App {
                     }
                 }
                 Ok(status) => {
-                    self.set_temporary_status(&format!("Editor '{}' exited with status: {}", editor, status));
+                    self.set_temporary_status(&format!(
+                        "Editor '{}' exited with status: {}",
+                        editor, status
+                    ));
                 }
                 Err(e) => {
-                    self.set_temporary_status(&format!("Failed to launch editor '{}': {}", editor, e));
+                    self.set_temporary_status(&format!(
+                        "Failed to launch editor '{}': {}",
+                        editor, e
+                    ));
                 }
             }
 
@@ -699,18 +697,6 @@ impl App {
         } else {
             self.set_temporary_status_static("Failed to load note for external editor!");
         }
-    }
-
-    pub fn confirm_encrypt_warning(&mut self, id: String) {
-        if self.external_editor_enabled {
-            self.open_note_in_external_editor(&id);
-        } else {
-            self.load_and_open_note(&id);
-        }
-    }
-
-    pub fn cancel_encrypt_warning(&mut self) {
-        self.set_default_status();
     }
 
     pub fn collapse_selected_folder(&mut self) {
@@ -850,7 +836,7 @@ impl App {
         if !folder.is_empty() {
             new_id = format!("{}/{}", folder, new_id);
         }
-        
+
         if self.external_editor_enabled {
             let new_note = Note {
                 title: String::from("Untitled note"),
@@ -858,7 +844,7 @@ impl App {
                 updated_at: now_unix_secs(),
                 tags: Vec::new(),
             };
-            if let Ok(_) = self.storage.save_note(&new_id, &new_note, self.encryption_enabled) {
+            if let Ok(_) = self.storage.save_note(&new_id, &new_note) {
                 let _ = self.refresh_notes();
                 self.open_note_in_external_editor(&new_id);
             }
@@ -881,15 +867,15 @@ impl App {
         if !folder.is_empty() {
             new_id = format!("{}/{}", folder, new_id);
         }
-        
+
         if self.external_editor_enabled {
             let new_note = Note {
-                title: title,
+                title,
                 content: String::new(),
                 updated_at: now_unix_secs(),
                 tags: Vec::new(),
             };
-            if let Ok(_) = self.storage.save_note(&new_id, &new_note, self.encryption_enabled) {
+            if let Ok(_) = self.storage.save_note(&new_id, &new_note) {
                 let _ = self.refresh_notes();
                 self.open_note_in_external_editor(&new_id);
             }
@@ -917,12 +903,15 @@ impl App {
 
         if self.external_editor_enabled {
             let new_note = Note {
-                title: rendered.title.clone().unwrap_or_else(|| String::from("Untitled note")),
+                title: rendered
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| String::from("Untitled note")),
                 content: rendered.content.clone(),
                 updated_at: now_unix_secs(),
                 tags: Vec::new(),
             };
-            if let Ok(_) = self.storage.save_note(&new_id, &new_note, self.encryption_enabled) {
+            if let Ok(_) = self.storage.save_note(&new_id, &new_note) {
                 let _ = self.refresh_notes();
                 self.open_note_in_external_editor(&new_id);
             }
@@ -943,7 +932,12 @@ impl App {
         self.set_default_status();
     }
 
-    pub fn start_note_from_template_with_title(&mut self, template: &Template, folder: String, title: String) {
+    pub fn start_note_from_template_with_title(
+        &mut self,
+        template: &Template,
+        folder: String,
+        title: String,
+    ) {
         let rendered = template.render();
 
         let mut new_id = self.storage.new_note_id();
@@ -953,12 +947,12 @@ impl App {
 
         if self.external_editor_enabled {
             let new_note = Note {
-                title: title,
+                title,
                 content: rendered.content.clone(),
                 updated_at: now_unix_secs(),
                 tags: Vec::new(),
             };
-            if let Ok(_) = self.storage.save_note(&new_id, &new_note, self.encryption_enabled) {
+            if let Ok(_) = self.storage.save_note(&new_id, &new_note) {
                 let _ = self.refresh_notes();
                 self.open_note_in_external_editor(&new_id);
             }
@@ -1029,20 +1023,24 @@ impl App {
             Some(id) => id.clone(),
             None => return,
         };
-        
+
+        if id.ends_with(".clin") {
+            return;
+        }
+
         let (updated_at, tags) = self
             .storage
             .load_note(&id)
             .map(|n| (n.updated_at, n.tags))
             .unwrap_or_else(|_| (now_unix_secs(), Vec::new()));
-            
+
         let note = Note {
             title,
             content,
             updated_at,
             tags,
         };
-        if let Ok(saved_id) = self.storage.save_note(&id, &note, self.encryption_enabled) {
+        if let Ok(saved_id) = self.storage.save_note(&id, &note) {
             self.editing_id = Some(saved_id);
         }
     }
@@ -1145,13 +1143,6 @@ impl App {
                 "Trash".into(),
                 false,
             ),
-            ConfirmAction::EncryptNote { .. } => (
-                "Confirm Encrypt".into(),
-                "Encrypt this note?".into(),
-                Some("The file will be encrypted on disk.".into()),
-                "Encrypt".into(),
-                false,
-            ),
             ConfirmAction::DeleteTag { tag } => (
                 "Confirm Delete Tag".into(),
                 format!("Delete tag \"{}\"?", tag),
@@ -1195,9 +1186,6 @@ impl App {
                 ConfirmAction::DeleteFolder { path } => {
                     self.confirm_delete_folder(path);
                 }
-                ConfirmAction::EncryptNote { note_id } => {
-                    self.confirm_encrypt_warning(note_id);
-                }
                 ConfirmAction::DeleteTag { tag } => {
                     self.confirm_delete_tag(tag);
                 }
@@ -1234,7 +1222,11 @@ impl App {
     }
 
     pub fn confirm_popup_activate(&mut self) {
-        let is_confirm = self.confirm_popup.as_ref().map(|p| p.selected_button == 0).unwrap_or(false);
+        let is_confirm = self
+            .confirm_popup
+            .as_ref()
+            .map(|p| p.selected_button == 0)
+            .unwrap_or(false);
         if is_confirm {
             self.confirm_action();
         } else {
@@ -1369,7 +1361,9 @@ impl App {
                 let mut all_folders = vec!["".to_string()]; // Root folder
                 all_folders.extend(folders);
                 self.folder_picker = Some(FolderPicker {
-                    mode: FolderPickerMode::MoveNote { note_id: note.id.clone() },
+                    mode: FolderPickerMode::MoveNote {
+                        note_id: note.id.clone(),
+                    },
                     folders: all_folders,
                     selected: 0,
                 });
@@ -1387,10 +1381,11 @@ impl App {
             if let Ok(folders) = self.storage.list_folders() {
                 let mut all_folders = vec!["".to_string()]; // Root folder
                 all_folders.extend(
-                    folders.into_iter()
-                        .filter(|f| f != &folder_path && !f.starts_with(&format!("{}/", folder_path)))
+                    folders.into_iter().filter(|f| {
+                        f != &folder_path && !f.starts_with(&format!("{}/", folder_path))
+                    }),
                 );
-                
+
                 self.folder_picker = Some(FolderPicker {
                     mode: FolderPickerMode::MoveFolder { folder_path },
                     folders: all_folders,
@@ -1434,12 +1429,12 @@ impl App {
                     } else {
                         format!("{}/{}", target_folder, folder_name)
                     };
-                    
+
                     if folder_path == new_path {
                         self.set_temporary_status_static("Folder is already in this location");
                         return;
                     }
-                    
+
                     if let Err(e) = self.storage.rename_folder(&folder_path, &new_path) {
                         self.set_temporary_status(&format!("Failed to move folder: {e}"));
                     } else {
@@ -1500,9 +1495,8 @@ impl App {
                 .collect();
 
             if let Ok(mut note) = self.storage.load_note(&popup.note_id) {
-                let is_clin = popup.note_id.ends_with(".clin");
                 note.tags = tags;
-                if let Err(e) = self.storage.save_note(&popup.note_id, &note, is_clin) {
+                if let Err(e) = self.storage.save_note(&popup.note_id, &note) {
                     self.set_temporary_status(&format!("Failed to save tags: {e}"));
                 } else {
                     let _ = self.refresh_notes();
@@ -1524,24 +1518,24 @@ impl App {
         if let Some(popup) = &mut self.tag_popup {
             let text = popup.input.lines().join("");
             let current_word = Self::get_current_tag_word(&text).to_lowercase();
-            
+
             // Get already entered tags
             let entered_tags: Vec<String> = text
                 .split(',')
                 .map(|s| s.trim().to_lowercase())
                 .filter(|s| !s.is_empty())
                 .collect();
-            
+
             if current_word.is_empty() {
                 popup.suggestions.clear();
             } else {
                 // Filter suggestions: match prefix, exclude already entered
-                popup.suggestions = popup.all_tags
+                popup.suggestions = popup
+                    .all_tags
                     .iter()
                     .filter(|tag| {
                         let tag_lower = tag.to_lowercase();
-                        tag_lower.starts_with(&current_word) 
-                            && !entered_tags.contains(&tag_lower)
+                        tag_lower.starts_with(&current_word) && !entered_tags.contains(&tag_lower)
                     })
                     .cloned()
                     .collect();
@@ -1564,13 +1558,13 @@ impl App {
         if let Some(popup) = &mut self.tag_popup {
             if let Some(suggestion) = popup.suggestions.get(popup.suggestion_index).cloned() {
                 let text = popup.input.lines().join("");
-                
+
                 // Find position of last comma
                 if let Some(last_comma) = text.rfind(',') {
                     // Replace everything after last comma with suggestion
                     let prefix = &text[..=last_comma];
                     let new_text = format!("{} {}, ", prefix, suggestion);
-                    
+
                     // Clear and re-insert
                     popup.input.select_all();
                     popup.input.cut();
@@ -1581,7 +1575,7 @@ impl App {
                     popup.input.cut();
                     popup.input.insert_str(&format!("{}, ", suggestion));
                 }
-                
+
                 popup.suggestions.clear();
                 popup.suggestion_index = 0;
             }
@@ -1603,8 +1597,7 @@ impl App {
                 if let Ok(mut note) = self.storage.load_note(&note_id) {
                     if note.tags.contains(&tag) {
                         note.tags.retain(|t| t != &tag);
-                        let is_clin = note_id.ends_with(".clin");
-                        let _ = self.storage.save_note(&note_id, &note, is_clin);
+                        let _ = self.storage.save_note(&note_id, &note);
                         count += 1;
                     }
                 }
@@ -1618,20 +1611,20 @@ impl App {
         if let Some(popup) = &mut self.tag_popup {
             popup.all_tags = live_tags;
             let text = popup.input.lines().join("");
-            
+
             // If the deleted tag was typed in the input, remove it
             let entered_tags: Vec<String> = text
                 .split(',')
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty() && s != &tag)
                 .collect();
-            
+
             let new_text = if entered_tags.is_empty() {
                 String::new()
             } else {
                 format!("{}, ", entered_tags.join(", "))
             };
-            
+
             popup.input.select_all();
             popup.input.cut();
             popup.input.insert_str(&new_text);
@@ -1643,7 +1636,7 @@ impl App {
         let all_tags = self.collect_live_tags();
         let mut input = TextArea::default();
         input.insert_str(self.filter_tags.join(", "));
-        
+
         self.filter_popup = Some(FilterTagPopup {
             input,
             all_tags,
@@ -1676,22 +1669,22 @@ impl App {
         if let Some(popup) = &mut self.filter_popup {
             let text = popup.input.lines().join("");
             let current_word = Self::get_current_tag_word(&text).to_lowercase();
-            
+
             let entered_tags: Vec<String> = text
                 .split(',')
                 .map(|s| s.trim().to_lowercase())
                 .filter(|s| !s.is_empty())
                 .collect();
-            
+
             if current_word.is_empty() {
                 popup.suggestions.clear();
             } else {
-                popup.suggestions = popup.all_tags
+                popup.suggestions = popup
+                    .all_tags
                     .iter()
                     .filter(|tag| {
                         let tag_lower = tag.to_lowercase();
-                        tag_lower.starts_with(&current_word) 
-                            && !entered_tags.contains(&tag_lower)
+                        tag_lower.starts_with(&current_word) && !entered_tags.contains(&tag_lower)
                     })
                     .cloned()
                     .collect();
@@ -1712,11 +1705,11 @@ impl App {
         if let Some(popup) = &mut self.filter_popup {
             if let Some(suggestion) = popup.suggestions.get(popup.suggestion_index).cloned() {
                 let text = popup.input.lines().join("");
-                
+
                 if let Some(last_comma) = text.rfind(',') {
                     let prefix = &text[..=last_comma];
                     let new_text = format!("{} {}, ", prefix, suggestion);
-                    
+
                     popup.input.select_all();
                     popup.input.cut();
                     popup.input.insert_str(&new_text);
@@ -1725,7 +1718,7 @@ impl App {
                     popup.input.cut();
                     popup.input.insert_str(&format!("{}, ", suggestion));
                 }
-                
+
                 popup.suggestions.clear();
                 popup.suggestion_index = 0;
             }
@@ -1760,15 +1753,6 @@ impl App {
         match open_in_file_manager(parent) {
             Ok(()) => self.set_temporary_status_static("Opened note file location"),
             Err(err) => self.set_temporary_status(&format!("Open location failed: {err:#}")),
-        }
-    }
-
-    pub fn toggle_encryption_mode(&mut self) {
-        self.encryption_enabled = !self.encryption_enabled;
-        self.set_default_status();
-        if let Ok(mut config) = crate::config::BootstrapConfig::load() {
-            config.encryption_enabled = self.encryption_enabled;
-            let _ = config.save();
         }
     }
 
@@ -1849,10 +1833,7 @@ impl App {
                 .borders(ratatui::widgets::Borders::ALL)
                 .title("New Note Name - Esc to cancel, Enter to create"),
         );
-        self.note_create_popup = Some(NoteCreatePopup {
-            folder,
-            input,
-        });
+        self.note_create_popup = Some(NoteCreatePopup { folder, input });
     }
 
     /// Confirm and create the note with the prompted name
@@ -1869,7 +1850,10 @@ impl App {
 
     /// Begin renaming a note (context-sensitive with folder rename)
     pub fn begin_rename_note(&mut self) {
-        if let Some(VisualItem::Note { summary_idx, id, .. }) = self.visual_list.get(self.visual_index).cloned() {
+        if let Some(VisualItem::Note {
+            summary_idx, id, ..
+        }) = self.visual_list.get(self.visual_index).cloned()
+        {
             let note = &self.notes[summary_idx];
             let mut input = TextArea::default();
             input.insert_str(&note.title);
@@ -1878,10 +1862,7 @@ impl App {
                     .borders(ratatui::widgets::Borders::ALL)
                     .title("Rename Note - Esc to cancel, Enter to save"),
             );
-            self.note_rename_popup = Some(NoteRenamePopup {
-                note_id: id,
-                input,
-            });
+            self.note_rename_popup = Some(NoteRenamePopup { note_id: id, input });
         } else {
             self.set_temporary_status_static("Select a note to rename");
         }
@@ -1910,7 +1891,8 @@ impl App {
 
     /// Duplicate the selected note
     pub fn duplicate_note(&mut self) {
-        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned() {
+        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned()
+        {
             match self.storage.duplicate_note(&id) {
                 Ok(_) => {
                     let _ = self.refresh_notes();
@@ -1927,7 +1909,8 @@ impl App {
 
     /// Toggle pin status of selected note
     pub fn toggle_pin(&mut self) {
-        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned() {
+        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned()
+        {
             match self.storage.toggle_pin(&id) {
                 Ok(pinned) => {
                     let _ = self.refresh_notes();
@@ -2013,10 +1996,10 @@ impl App {
                             self.folder_expanded.insert(path.clone());
                         }
                     }
-                    
+
                     // Rebuild visual list with newly expanded folders
                     let _ = self.refresh_visual_list();
-                    
+
                     // Find the note in the updated visual_list
                     for (idx, item) in self.visual_list.iter().enumerate() {
                         if let VisualItem::Note { summary_idx, .. } = item {
@@ -2155,7 +2138,8 @@ impl App {
                             self.set_temporary_status_static("Note deleted, trash is now empty");
                         } else {
                             trash.items = items;
-                            trash.selected = trash.selected.min(trash.items.len().saturating_sub(1));
+                            trash.selected =
+                                trash.selected.min(trash.items.len().saturating_sub(1));
                             self.set_temporary_status_static("Note permanently deleted");
                         }
                     }
@@ -2231,7 +2215,8 @@ impl App {
             return;
         }
 
-        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned() {
+        if let Some(VisualItem::Note { id, .. }) = self.visual_list.get(self.visual_index).cloned()
+        {
             if let Ok(note) = self.storage.load_note(&id) {
                 let width = 80u16.saturating_sub(2).max(40);
                 let mut renderer = MarkdownRenderer::new(width);
@@ -2277,6 +2262,5 @@ impl App {
 pub enum EditFocus {
     Title,
     Body,
-    EncryptionToggle,
     ExternalEditorToggle,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,9 @@ pub struct BootstrapConfig {
     /// Whether the preview pane is enabled by default
     #[serde(default = "default_preview_enabled")]
     pub preview_enabled: bool,
+    /// Whether the editor markdown preview panel is enabled by default
+    #[serde(default)]
+    pub markdown_preview_enabled: bool,
 }
 
 fn default_encryption_enabled() -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,19 +26,12 @@ pub struct BootstrapConfig {
     /// Whether external editor mode is enabled
     #[serde(default)]
     pub external_editor_enabled: bool,
-    /// Whether new notes should be encrypted by default
-    #[serde(default = "default_encryption_enabled")]
-    pub encryption_enabled: bool,
     /// Whether the preview pane is enabled by default
     #[serde(default = "default_preview_enabled")]
     pub preview_enabled: bool,
     /// Whether the editor markdown preview panel is enabled by default
     #[serde(default)]
     pub markdown_preview_enabled: bool,
-}
-
-fn default_encryption_enabled() -> bool {
-    true
 }
 
 fn default_preview_enabled() -> bool {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,8 @@
 pub const FILE_MAGIC: &[u8; 5] = b"CLIN1";
 pub const NONCE_LEN: usize = 12;
 pub const LIST_HELP_HINTS: &str = "j/k move  Enter open  r rename  d delete  p pin  s sort  Ctrl+f search  P preview  ? help  q quit";
-pub const EDIT_HELP_HINTS: &str = "Esc back   Tab change focus   Ctrl+Q quit";
+pub const EDIT_HELP_HINTS: &str =
+    "Esc back   Tab change focus   Ctrl+Q quit   Ctrl+P markdown preview";
 pub const HELP_PAGE_HINTS: &str = "Esc/q/?/F1 close help";
 pub const _HELP_PAGE_TEXT: &str = "clin help\n\
 \n\
@@ -23,7 +24,7 @@ Notes view shortcuts\n\
 - p: pin/unpin note\n\
 - s: cycle sort options\n\
 - Ctrl+f: search notes by title\n\
-- Shift+P: toggle preview pane\n\
+- Shift+P: toggle preview pane (uses glow for markdown)\n\
 - Shift+T: open trash\n\
 - d/Delete: move note to trash\n\
 - y or Enter: confirm delete\n\
@@ -41,6 +42,7 @@ Editor shortcuts\n\
 - Tab: change focus (Title, Content, Encryption toggle button)\n\
 - Esc: return to notes view\n\
 - Ctrl+Q: quit app\n\
+- Ctrl+P: toggle markdown preview panel (uses glow)\n\
 - Mouse selection in content area\n\
 - Clipboard: Ctrl+C/Ctrl+X/Ctrl+V, Ctrl+Insert, Shift+Insert, Shift+Delete\n\
 - Edit: Ctrl+A, Ctrl+Z, Ctrl+Y, Ctrl+Shift+Z\n\

--- a/src/events.rs
+++ b/src/events.rs
@@ -479,6 +479,15 @@ pub fn handle_edit_keys(app: &mut App, key: KeyEvent, focus: &mut EditFocus) -> 
         return false;
     }
 
+    // Toggle markdown preview
+    if app
+        .keybinds
+        .matches_edit(EditAction::ToggleMarkdownPreview, &key)
+    {
+        app.toggle_markdown_preview();
+        return false;
+    }
+
     match *focus {
         EditFocus::Title => {
             if key.code == KeyCode::Enter {
@@ -556,6 +565,30 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
         list_area.height.saturating_sub(2),
     );
 
+    // Check if scroll is in preview pane area
+    if app.preview_enabled {
+        let main_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(chunks[1]);
+        let preview_area = main_chunks[1];
+
+        if contains_cell(preview_area, mouse_event.column, mouse_event.row) {
+            if mouse_event.kind == MouseEventKind::ScrollUp {
+                if let Some(renderer) = &mut app.preview_renderer {
+                    renderer.scroll_up(3);
+                }
+                return;
+            }
+            if mouse_event.kind == MouseEventKind::ScrollDown {
+                if let Some(renderer) = &mut app.preview_renderer {
+                    renderer.scroll_down(3, preview_area.height.saturating_sub(2));
+                }
+                return;
+            }
+        }
+    }
+
     if mouse_event.kind == MouseEventKind::ScrollUp {
         let current = app.list_state.selected().unwrap_or(0);
         app.list_state.select(Some(current.saturating_sub(1)));
@@ -631,7 +664,8 @@ pub fn handle_edit_mouse(
     }
 
     if mouse_event.kind == MouseEventKind::Down(MouseButton::Right) {
-        let (title_inner, body_inner) = edit_view_input_areas(terminal_area);
+        let (title_inner, body_inner) =
+            edit_view_input_areas(terminal_area, app.markdown_preview_enabled);
 
         if contains_cell(title_inner, mouse_event.column, mouse_event.row) {
             *focus = EditFocus::Title;
@@ -661,7 +695,31 @@ pub fn handle_edit_mouse(
         return;
     }
 
-    let (title_inner, body_inner) = edit_view_input_areas(terminal_area);
+    let (title_inner, body_inner) =
+        edit_view_input_areas(terminal_area, app.markdown_preview_enabled);
+
+    // Handle scroll in markdown preview pane
+    if app.markdown_preview_enabled {
+        if let Some(md_area) = edit_view_md_preview_area(terminal_area) {
+            if contains_cell(md_area, mouse_event.column, mouse_event.row) {
+                match mouse_event.kind {
+                    MouseEventKind::ScrollUp => {
+                        if let Some(renderer) = &mut app.md_preview_renderer {
+                            renderer.scroll_up(3);
+                        }
+                        return;
+                    }
+                    MouseEventKind::ScrollDown => {
+                        if let Some(renderer) = &mut app.md_preview_renderer {
+                            renderer.scroll_down(3, md_area.height.saturating_sub(2));
+                        }
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 
     match mouse_event.kind {
         MouseEventKind::Down(MouseButton::Left) => {
@@ -773,7 +831,7 @@ pub fn move_textarea_cursor_to_mouse(
     textarea.move_cursor(CursorMove::Jump(target_row as u16, target_col as u16));
 }
 
-pub fn edit_view_input_areas(area: Rect) -> (Rect, Rect) {
+pub fn edit_view_input_areas(area: Rect, md_preview: bool) -> (Rect, Rect) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -787,12 +845,44 @@ pub fn edit_view_input_areas(area: Rect) -> (Rect, Rect) {
         vertical: 1,
         horizontal: 1,
     });
-    let body_inner = chunks[1].inner(Margin {
+
+    let body_area = if md_preview {
+        let content_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(chunks[1]);
+        content_chunks[0]
+    } else {
+        chunks[1]
+    };
+
+    let body_inner = body_area.inner(Margin {
         vertical: 1,
         horizontal: 1,
     });
 
     (title_inner, body_inner)
+}
+
+pub fn edit_view_md_preview_area(area: Rect) -> Option<Rect> {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(3),
+        ])
+        .split(area);
+
+    let content_chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(chunks[1]);
+
+    Some(content_chunks[1].inner(Margin {
+        vertical: 1,
+        horizontal: 1,
+    }))
 }
 
 pub fn contains_cell(rect: Rect, col: u16, row: u16) -> bool {

--- a/src/events.rs
+++ b/src/events.rs
@@ -245,22 +245,12 @@ pub fn handle_list_keys(app: &mut App, key: KeyEvent) -> bool {
     // Cycle focus with Tab
     if app.keybinds.matches_list(ListAction::CycleFocus, &key) {
         app.list_focus = match app.list_focus {
-            ListFocus::Notes => ListFocus::EncryptionToggle,
-            ListFocus::EncryptionToggle => ListFocus::ExternalEditorToggle,
+            ListFocus::Notes => ListFocus::ExternalEditorToggle,
             ListFocus::ExternalEditorToggle => ListFocus::Notes,
         };
         return false;
     }
 
-    // Handle toggle buttons when focused
-    if app.list_focus == ListFocus::EncryptionToggle {
-        if app.keybinds.matches_list(ListAction::ToggleButton, &key) {
-            app.toggle_encryption_mode();
-        } else if app.keybinds.matches_list(ListAction::Quit, &key) {
-            return true;
-        }
-        return false;
-    }
     if app.list_focus == ListFocus::ExternalEditorToggle {
         if app.keybinds.matches_list(ListAction::ToggleButton, &key) {
             app.toggle_external_editor_mode();
@@ -464,8 +454,7 @@ pub fn handle_edit_keys(app: &mut App, key: KeyEvent, focus: &mut EditFocus) -> 
     if app.keybinds.matches_edit(EditAction::CycleFocus, &key) {
         *focus = match *focus {
             EditFocus::Title => EditFocus::Body,
-            EditFocus::Body => EditFocus::EncryptionToggle,
-            EditFocus::EncryptionToggle => EditFocus::ExternalEditorToggle,
+            EditFocus::Body => EditFocus::ExternalEditorToggle,
             EditFocus::ExternalEditorToggle => EditFocus::Title,
         };
         return false;
@@ -509,11 +498,6 @@ pub fn handle_edit_keys(app: &mut App, key: KeyEvent, focus: &mut EditFocus) -> 
                 return false;
             }
             app.editor.input(Input::from(key));
-        }
-        EditFocus::EncryptionToggle => {
-            if app.keybinds.matches_edit(EditAction::ToggleButton, &key) {
-                app.toggle_encryption_mode();
-            }
         }
         EditFocus::ExternalEditorToggle => {
             if app.keybinds.matches_edit(EditAction::ToggleButton, &key) {

--- a/src/events.rs
+++ b/src/events.rs
@@ -396,6 +396,10 @@ pub fn handle_list_keys(app: &mut App, key: KeyEvent) -> bool {
         app.toggle_preview();
         return false;
     }
+    if app.keybinds.matches_list(ListAction::OpenGraph, &key) {
+        app.open_graph_view();
+        return false;
+    }
 
     // Handle vim-style 'g' for gg (jump to top)
     if key.code == KeyCode::Char('g') {

--- a/src/graph/input.rs
+++ b/src/graph/input.rs
@@ -1,0 +1,168 @@
+use std::sync::{Arc, RwLock};
+
+use crossterm::event::{KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
+
+use super::GraphState;
+
+pub fn handle_graph_keys(app: &mut crate::app::App, key: KeyEvent) -> bool {
+    let keybinds = &app.keybinds;
+
+    if keybinds.matches_graph(crate::keybinds::GraphAction::Quit, &key) {
+        app.close_graph_view();
+        return false;
+    }
+    if keybinds.matches_graph(crate::keybinds::GraphAction::Help, &key) {
+        app.open_help_page();
+        return false;
+    }
+
+    if app.graph_state.is_none() {
+        return false;
+    }
+
+    if keybinds.matches_graph(crate::keybinds::GraphAction::PanUp, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.pan_up();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::PanDown, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.pan_down();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::PanLeft, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.pan_left();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::PanRight, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.pan_right();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::ZoomIn, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.zoom_in();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::ZoomOut, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.viewport.zoom_out();
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::OpenNote, &key) {
+        let note_id = {
+            let state = app.graph_state.as_ref().unwrap();
+            let guard = state.read().unwrap_or_else(|e| e.into_inner());
+            guard.selected_node.and_then(|idx| {
+                guard
+                    .simulation
+                    .get_graph()
+                    .node_weight(idx)
+                    .map(|n| n.data.note_id.clone())
+            })
+        };
+        if let Some(id) = note_id {
+            app.open_note_from_graph(&id);
+        }
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::ToggleLabels, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        guard.show_labels = !guard.show_labels;
+    } else if keybinds.matches_graph(crate::keybinds::GraphAction::AutoFit, &key) {
+        let state = app.graph_state.as_ref().unwrap();
+        let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+        let viewport = guard.viewport.clone();
+        let vp = viewport.auto_fit_from_graph(guard.simulation.get_graph());
+        guard.viewport = vp;
+    }
+
+    false
+}
+
+#[derive(Default)]
+pub struct GraphMouseState {
+    pub drag_origin: Option<(u16, u16)>,
+    pub is_panning: bool,
+}
+
+pub fn handle_graph_mouse(
+    state: &Arc<RwLock<GraphState>>,
+    mouse_event: MouseEvent,
+    area: Rect,
+    mouse_state: &mut GraphMouseState,
+) {
+    match mouse_event.kind {
+        MouseEventKind::ScrollUp => {
+            let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+            guard.viewport.zoom_in();
+        }
+        MouseEventKind::ScrollDown => {
+            let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+            guard.viewport.zoom_out();
+        }
+        MouseEventKind::Down(MouseButton::Left) => {
+            let (wx, wy) = {
+                let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                guard
+                    .viewport
+                    .screen_to_world(mouse_event.column, mouse_event.row, area)
+            };
+
+            let hit = {
+                let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                guard.viewport.hit_test(wx, wy, &guard)
+            };
+
+            if let Some(node_idx) = hit {
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                guard.selected_node = Some(node_idx);
+                guard.dragging_node = Some(node_idx);
+                mouse_state.drag_origin = Some((mouse_event.column, mouse_event.row));
+                mouse_state.is_panning = false;
+            } else {
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                guard.selected_node = None;
+                guard.dragging_node = None;
+                mouse_state.drag_origin = Some((mouse_event.column, mouse_event.row));
+                mouse_state.is_panning = true;
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            let Some((orig_col, orig_row)) = mouse_state.drag_origin else {
+                return;
+            };
+
+            if mouse_state.is_panning {
+                let dx = (mouse_event.column as f64 - orig_col as f64) * 0.5;
+                let dy = -(mouse_event.row as f64 - orig_row as f64) * 0.5;
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                guard.viewport.pan(-dx, dy);
+                mouse_state.drag_origin = Some((mouse_event.column, mouse_event.row));
+            } else {
+                let (wx, wy) = {
+                    let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                    guard
+                        .viewport
+                        .screen_to_world(mouse_event.column, mouse_event.row, area)
+                };
+
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                if let Some(node_idx) = guard.dragging_node {
+                    let graph = guard.simulation.get_graph_mut();
+                    if let Some(node) = graph.node_weight_mut(node_idx) {
+                        node.location.x = wx as f32;
+                        node.location.y = wy as f32;
+                        node.velocity = fdg_sim::glam::Vec3::ZERO;
+                    }
+                    guard.is_settled = false;
+                }
+                mouse_state.drag_origin = Some((mouse_event.column, mouse_event.row));
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            {
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                guard.dragging_node = None;
+            }
+            mouse_state.drag_origin = None;
+            mouse_state.is_panning = false;
+        }
+        _ => {}
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,0 +1,102 @@
+pub mod input;
+pub mod physics;
+pub mod render;
+pub mod viewport;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use fdg_sim::petgraph::graph::NodeIndex;
+use fdg_sim::{ForceGraph, ForceGraphHelper, Simulation, SimulationParameters};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use crate::storage::Storage;
+
+pub struct GraphNodeData {
+    pub note_id: String,
+    pub title: String,
+    pub is_encrypted: bool,
+    pub tags: Vec<String>,
+}
+
+pub struct GraphState {
+    pub simulation: Simulation<GraphNodeData, ()>,
+    pub viewport: viewport::Viewport,
+    pub selected_node: Option<NodeIndex>,
+    pub dragging_node: Option<NodeIndex>,
+    pub is_settled: bool,
+    pub show_labels: bool,
+}
+
+static WIKILINK_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\[\[([^\]|]+)(?:\|[^\]]+)?\]\]").unwrap());
+
+fn extract_wikilinks(content: &str) -> Vec<String> {
+    WIKILINK_RE
+        .captures_iter(content)
+        .filter_map(|c| c.get(1).map(|m| m.as_str().trim().to_string()))
+        .collect()
+}
+
+pub fn build_graph(storage: &Storage) -> Result<ForceGraph<GraphNodeData, ()>> {
+    let note_ids = storage.list_note_ids()?;
+    let mut graph: ForceGraph<GraphNodeData, ()> = ForceGraph::default();
+    let mut title_to_index: HashMap<String, NodeIndex> = HashMap::new();
+
+    for id in &note_ids {
+        let summary = match storage.load_note_summary(id) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        let is_encrypted = id.ends_with(".clin");
+        let data = GraphNodeData {
+            note_id: id.clone(),
+            title: summary.title.clone(),
+            is_encrypted,
+            tags: summary.tags.clone(),
+        };
+
+        let idx = graph.add_force_node(&summary.title, data);
+        title_to_index.insert(summary.title.to_lowercase(), idx);
+    }
+
+    for id in &note_ids {
+        if id.ends_with(".clin") {
+            continue;
+        }
+
+        let note = match storage.load_note(id) {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+
+        let source_title_lower = note.title.to_lowercase();
+        let source_idx = match title_to_index.get(&source_title_lower) {
+            Some(&idx) => idx,
+            None => continue,
+        };
+
+        let links = extract_wikilinks(&note.content);
+        let mut seen_targets = std::collections::HashSet::new();
+        for link in links {
+            let target_lower = link.to_lowercase();
+            if let Some(&target_idx) = title_to_index.get(&target_lower)
+                && target_idx != source_idx
+                && seen_targets.insert(target_idx)
+                && graph.edges_connecting(source_idx, target_idx).count() == 0
+            {
+                graph.add_edge(source_idx, target_idx, ());
+            }
+        }
+    }
+
+    Ok(graph)
+}
+
+pub fn create_simulation(graph: ForceGraph<GraphNodeData, ()>) -> Simulation<GraphNodeData, ()> {
+    let force = fdg_sim::force::handy(45.0, 0.975, true, true);
+    let params = SimulationParameters::new(200.0, fdg_sim::Dimensions::Two, force);
+    Simulation::from_graph(graph, params)
+}

--- a/src/graph/physics.rs
+++ b/src/graph/physics.rs
@@ -1,0 +1,32 @@
+use std::sync::{Arc, RwLock, mpsc};
+
+use super::GraphState;
+
+pub fn start_physics(state: Arc<RwLock<GraphState>>, kill_rx: mpsc::Receiver<()>) {
+    std::thread::spawn(move || {
+        loop {
+            if kill_rx.try_recv().is_ok() {
+                break;
+            }
+
+            let should_update = {
+                let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                !guard.is_settled
+            };
+
+            if should_update {
+                let mut guard = state.write().unwrap_or_else(|e| e.into_inner());
+                guard.simulation.update(0.016);
+
+                let graph = guard.simulation.get_graph();
+                let energy: f32 = graph.node_weights().map(|n| n.velocity.length()).sum();
+
+                if energy < 0.05 * graph.node_count() as f32 {
+                    guard.is_settled = true;
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(16));
+        }
+    });
+}

--- a/src/graph/render.rs
+++ b/src/graph/render.rs
@@ -1,0 +1,232 @@
+use std::collections::HashMap;
+
+use fdg_sim::petgraph::visit::EdgeRef;
+use ratatui::style::Color;
+use ratatui::widgets::canvas::{Canvas, Line, Painter, Shape};
+
+use super::GraphState;
+
+const TAG_PALETTE: &[Color] = &[
+    Color::Cyan,
+    Color::Yellow,
+    Color::Green,
+    Color::Magenta,
+    Color::Blue,
+    Color::LightRed,
+    Color::LightCyan,
+    Color::LightGreen,
+    Color::LightMagenta,
+    Color::LightBlue,
+];
+
+fn tag_color(tag: &str) -> Color {
+    let hash = tag
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    TAG_PALETTE[(hash as usize) % TAG_PALETTE.len()]
+}
+
+#[derive(Clone)]
+struct EdgeData {
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+}
+
+#[derive(Clone)]
+struct NodeData {
+    x: f64,
+    y: f64,
+    color: Color,
+    is_selected: bool,
+}
+
+struct LabelData {
+    x: f64,
+    y: f64,
+    text: String,
+}
+
+struct GraphEdgesData {
+    edges: Vec<EdgeData>,
+}
+
+impl Shape for GraphEdgesData {
+    fn draw(&self, painter: &mut Painter) {
+        for edge in &self.edges {
+            Line {
+                x1: edge.x1,
+                y1: edge.y1,
+                x2: edge.x2,
+                y2: edge.y2,
+                color: Color::DarkGray,
+            }
+            .draw(painter);
+        }
+    }
+}
+
+struct GraphNodesData {
+    nodes: Vec<NodeData>,
+}
+
+impl Shape for GraphNodesData {
+    fn draw(&self, painter: &mut Painter) {
+        for node in &self.nodes {
+            let radius = if node.is_selected { 3.0 } else { 2.0 };
+            let steps = 16u32;
+            for i in 0..steps {
+                let a1 = (i as f64) * std::f64::consts::TAU / (steps as f64);
+                let a2 = ((i + 1) as f64) * std::f64::consts::TAU / (steps as f64);
+                Line {
+                    x1: node.x + radius * a1.cos(),
+                    y1: node.y + radius * a1.sin(),
+                    x2: node.x + radius * a2.cos(),
+                    y2: node.y + radius * a2.sin(),
+                    color: node.color,
+                }
+                .draw(painter);
+            }
+        }
+    }
+}
+
+pub fn draw_graph_view(frame: &mut ratatui::Frame, state: &GraphState) {
+    let area = frame.area();
+    let aspect = area.width as f64 / area.height as f64;
+    let viewport = &state.viewport;
+
+    let tag_colors: HashMap<String, Color> = {
+        let graph = state.simulation.get_graph();
+        let mut colors = HashMap::new();
+        for node in graph.node_weights() {
+            if let Some(tag) = node.data.tags.first() {
+                colors.entry(tag.clone()).or_insert_with(|| tag_color(tag));
+            }
+        }
+        colors
+    };
+
+    let graph = state.simulation.get_graph();
+
+    let edges: Vec<EdgeData> = {
+        use fdg_sim::petgraph::visit::IntoEdgeReferences;
+        graph
+            .edge_references()
+            .map(|edge| {
+                let src = &graph[edge.source()];
+                let tgt = &graph[edge.target()];
+                EdgeData {
+                    x1: src.location.x as f64,
+                    y1: src.location.y as f64,
+                    x2: tgt.location.x as f64,
+                    y2: tgt.location.y as f64,
+                }
+            })
+            .collect()
+    };
+
+    let nodes: Vec<NodeData> = graph
+        .node_indices()
+        .map(|idx| {
+            let node = &graph[idx];
+            let color = if node.data.is_encrypted {
+                Color::Red
+            } else if let Some(tag) = node.data.tags.first() {
+                tag_colors.get(tag).copied().unwrap_or(Color::Gray)
+            } else {
+                Color::Gray
+            };
+            NodeData {
+                x: node.location.x as f64,
+                y: node.location.y as f64,
+                color,
+                is_selected: state.selected_node == Some(idx),
+            }
+        })
+        .collect();
+
+    let labels: Vec<LabelData> = if state.show_labels {
+        graph
+            .node_indices()
+            .map(|idx| {
+                let node = &graph[idx];
+                LabelData {
+                    x: node.location.x as f64,
+                    y: node.location.y as f64 + 4.0,
+                    text: truncate_owned(&node.data.title, 20),
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let node_count = graph.node_count();
+    let edge_count = graph.edge_count();
+
+    let x_bounds = viewport.x_bounds(aspect);
+    let y_bounds = viewport.y_bounds();
+
+    let canvas = Canvas::default()
+        .x_bounds(x_bounds)
+        .y_bounds(y_bounds)
+        .block(
+            ratatui::widgets::Block::default()
+                .borders(ratatui::widgets::Borders::ALL)
+                .title("Graph View"),
+        )
+        .marker(ratatui::symbols::Marker::Braille)
+        .paint(move |ctx| {
+            ctx.draw(&GraphEdgesData {
+                edges: edges.clone(),
+            });
+            ctx.layer();
+            ctx.draw(&GraphNodesData {
+                nodes: nodes.clone(),
+            });
+
+            for label in &labels {
+                ctx.print(label.x, label.y, label.text.clone());
+            }
+        });
+
+    frame.render_widget(canvas, area);
+
+    let selected_info = state
+        .selected_node
+        .and_then(|idx| graph.node_weight(idx))
+        .map(|n| {
+            let enc = if n.data.is_encrypted { " [ENC]" } else { "" };
+            format!(" | Selected: {}{}", n.data.title, enc)
+        })
+        .unwrap_or_default();
+
+    let status = format!(
+        "Notes: {} | Links: {}{} | Esc: back | +/-: zoom | Scroll: zoom | Drag: move",
+        node_count, edge_count, selected_info
+    );
+
+    let status_bar = ratatui::widgets::Paragraph::new(status)
+        .style(ratatui::style::Style::default().fg(ratatui::style::Color::DarkGray));
+    let status_area = ratatui::layout::Rect::new(
+        area.x + 1,
+        area.y + area.height.saturating_sub(1),
+        area.width.saturating_sub(2),
+        1,
+    );
+    frame.render_widget(status_bar, status_area);
+}
+
+fn truncate_owned(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        let mut end = max_len.saturating_sub(1);
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}

--- a/src/graph/viewport.rs
+++ b/src/graph/viewport.rs
@@ -1,0 +1,167 @@
+use ratatui::layout::Rect;
+
+use super::GraphState;
+
+const PAN_AMOUNT: f64 = 15.0;
+const ZOOM_FACTOR: f64 = 1.15;
+
+#[derive(Clone)]
+pub struct Viewport {
+    pub center_x: f64,
+    pub center_y: f64,
+    pub zoom: f64,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            center_x: 0.0,
+            center_y: 0.0,
+            zoom: 1.0,
+        }
+    }
+}
+
+impl Viewport {
+    pub fn x_bounds(&self, aspect: f64) -> [f64; 2] {
+        let half_w = aspect * 100.0 / self.zoom;
+        [self.center_x - half_w, self.center_x + half_w]
+    }
+
+    pub fn y_bounds(&self) -> [f64; 2] {
+        let half_h = 100.0 / self.zoom;
+        [self.center_y - half_h, self.center_y + half_h]
+    }
+
+    pub fn screen_to_world(&self, col: u16, row: u16, area: Rect) -> (f64, f64) {
+        let aspect = area.width as f64 / area.height as f64;
+        let [x_left, x_right] = self.x_bounds(aspect);
+        let [y_bottom, y_top] = self.y_bounds();
+
+        let wx = x_left + (col as f64 / area.width as f64) * (x_right - x_left);
+        let wy = y_top - (row as f64 / area.height as f64) * (y_top - y_bottom);
+        (wx, wy)
+    }
+
+    pub fn auto_fit(&mut self, state: &GraphState) {
+        let graph = state.simulation.get_graph();
+        if graph.node_count() == 0 {
+            *self = Viewport::default();
+            return;
+        }
+
+        let mut min_x = f64::MAX;
+        let mut max_x = f64::MIN;
+        let mut min_y = f64::MAX;
+        let mut max_y = f64::MIN;
+
+        for node in graph.node_weights() {
+            let x = node.location.x as f64;
+            let y = node.location.y as f64;
+            min_x = min_x.min(x);
+            max_x = max_x.max(x);
+            min_y = min_y.min(y);
+            max_y = max_y.max(y);
+        }
+
+        self.center_x = (min_x + max_x) / 2.0;
+        self.center_y = (min_y + max_y) / 2.0;
+
+        let range_x = (max_x - min_x).max(1.0);
+        let range_y = (max_y - min_y).max(1.0);
+        let range = range_x.max(range_y) * 1.4;
+        self.zoom = 200.0 / range;
+    }
+
+    pub fn auto_fit_from_graph(
+        &self,
+        graph: &fdg_sim::ForceGraph<super::GraphNodeData, ()>,
+    ) -> Viewport {
+        let mut vp = self.clone();
+        if graph.node_count() == 0 {
+            return Viewport::default();
+        }
+
+        let mut min_x = f64::MAX;
+        let mut max_x = f64::MIN;
+        let mut min_y = f64::MAX;
+        let mut max_y = f64::MIN;
+
+        for node in graph.node_weights() {
+            let x = node.location.x as f64;
+            let y = node.location.y as f64;
+            min_x = min_x.min(x);
+            max_x = max_x.max(x);
+            min_y = min_y.min(y);
+            max_y = max_y.max(y);
+        }
+
+        vp.center_x = (min_x + max_x) / 2.0;
+        vp.center_y = (min_y + max_y) / 2.0;
+
+        let range_x = (max_x - min_x).max(1.0);
+        let range_y = (max_y - min_y).max(1.0);
+        let range = range_x.max(range_y) * 1.4;
+        vp.zoom = 200.0 / range;
+        vp
+    }
+
+    pub fn pan(&mut self, dx: f64, dy: f64) {
+        let scale = 100.0 / self.zoom;
+        self.center_x += dx * scale;
+        self.center_y += dy * scale;
+    }
+
+    pub fn pan_up(&mut self) {
+        self.pan(0.0, PAN_AMOUNT * 0.15);
+    }
+
+    pub fn pan_down(&mut self) {
+        self.pan(0.0, -PAN_AMOUNT * 0.15);
+    }
+
+    pub fn pan_left(&mut self) {
+        self.pan(-PAN_AMOUNT * 0.15, 0.0);
+    }
+
+    pub fn pan_right(&mut self) {
+        self.pan(PAN_AMOUNT * 0.15, 0.0);
+    }
+
+    pub fn zoom_in(&mut self) {
+        self.zoom *= ZOOM_FACTOR;
+    }
+
+    pub fn zoom_out(&mut self) {
+        self.zoom /= ZOOM_FACTOR;
+        if self.zoom < 0.01 {
+            self.zoom = 0.01;
+        }
+    }
+
+    pub fn hit_test(
+        &self,
+        world_x: f64,
+        world_y: f64,
+        state: &GraphState,
+    ) -> Option<fdg_sim::petgraph::graph::NodeIndex> {
+        let graph = state.simulation.get_graph();
+        let threshold = 8.0 / self.zoom;
+        let mut best: Option<(fdg_sim::petgraph::graph::NodeIndex, f64)> = None;
+
+        for idx in graph.node_indices() {
+            let node = &graph[idx];
+            let dx = node.location.x as f64 - world_x;
+            let dy = node.location.y as f64 - world_y;
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist < threshold {
+                match best {
+                    Some((_, best_dist)) if dist >= best_dist => {}
+                    _ => best = Some((idx, dist)),
+                }
+            }
+        }
+
+        best.map(|(idx, _)| idx)
+    }
+}

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -248,6 +248,7 @@ pub enum EditAction {
     DeleteNextWord,
     MoveToTop,
     MoveToBottom,
+    ToggleMarkdownPreview,
 }
 
 /// Actions that can be bound to keys in help view
@@ -475,6 +476,10 @@ impl Default for Keybinds {
         );
         edit.insert(EditAction::MoveToTop, vec![KeyCombo::ctrl(KeyCode::Home)]);
         edit.insert(EditAction::MoveToBottom, vec![KeyCombo::ctrl(KeyCode::End)]);
+        edit.insert(
+            EditAction::ToggleMarkdownPreview,
+            vec![KeyCombo::ctrl(KeyCode::Char('p'))],
+        );
 
         let mut help = HashMap::new();
         help.insert(
@@ -706,6 +711,7 @@ fn parse_edit_action(s: &str) -> Option<EditAction> {
         "delete_next_word" => Some(EditAction::DeleteNextWord),
         "move_to_top" => Some(EditAction::MoveToTop),
         "move_to_bottom" => Some(EditAction::MoveToBottom),
+        "toggle_markdown_preview" => Some(EditAction::ToggleMarkdownPreview),
         _ => None,
     }
 }
@@ -773,6 +779,7 @@ fn edit_action_to_string(action: EditAction) -> &'static str {
         EditAction::DeleteNextWord => "delete_next_word",
         EditAction::MoveToTop => "move_to_top",
         EditAction::MoveToBottom => "move_to_bottom",
+        EditAction::ToggleMarkdownPreview => "toggle_markdown_preview",
     }
 }
 

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -227,6 +227,7 @@ pub enum ListAction {
     PageDown,      // Half page down (Ctrl+d)
     OpenTrash,     // Open trash view
     TogglePreview, // Toggle preview pane
+    OpenGraph,     // Open graph view
 }
 
 /// Actions that can be bound to keys in edit view
@@ -260,6 +261,22 @@ pub enum HelpAction {
     ScrollDown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GraphAction {
+    Quit,
+    PanUp,
+    PanDown,
+    PanLeft,
+    PanRight,
+    ZoomIn,
+    ZoomOut,
+    OpenNote,
+    ToggleLabels,
+    AutoFit,
+    Help,
+}
+
 /// TOML representation of keybinds for serialization
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct KeybindsToml {
@@ -269,6 +286,8 @@ pub struct KeybindsToml {
     pub edit: HashMap<String, Vec<String>>,
     #[serde(default)]
     pub help: HashMap<String, Vec<String>>,
+    #[serde(default)]
+    pub graph: HashMap<String, Vec<String>>,
 }
 
 /// Main keybinds configuration
@@ -277,6 +296,7 @@ pub struct Keybinds {
     pub list: HashMap<ListAction, Vec<KeyCombo>>,
     pub edit: HashMap<EditAction, Vec<KeyCombo>>,
     pub help: HashMap<HelpAction, Vec<KeyCombo>>,
+    pub graph: HashMap<GraphAction, Vec<KeyCombo>>,
 }
 
 impl Default for Keybinds {
@@ -421,6 +441,10 @@ impl Default for Keybinds {
             ListAction::TogglePreview,
             vec![KeyCombo::shift(KeyCode::Char('P'))],
         );
+        list.insert(
+            ListAction::OpenGraph,
+            vec![KeyCombo::shift(KeyCode::Char('G'))],
+        );
 
         let mut edit = HashMap::new();
         edit.insert(EditAction::Quit, vec![KeyCombo::ctrl(KeyCode::Char('q'))]);
@@ -506,7 +530,49 @@ impl Default for Keybinds {
             ],
         );
 
-        Self { list, edit, help }
+        let mut graph = HashMap::new();
+        graph.insert(GraphAction::Quit, vec![KeyCombo::simple(KeyCode::Esc)]);
+        graph.insert(GraphAction::PanUp, vec![KeyCombo::simple(KeyCode::Up)]);
+        graph.insert(GraphAction::PanDown, vec![KeyCombo::simple(KeyCode::Down)]);
+        graph.insert(GraphAction::PanLeft, vec![KeyCombo::simple(KeyCode::Left)]);
+        graph.insert(
+            GraphAction::PanRight,
+            vec![KeyCombo::simple(KeyCode::Right)],
+        );
+        graph.insert(
+            GraphAction::ZoomIn,
+            vec![KeyCombo::simple(KeyCode::Char('+'))],
+        );
+        graph.insert(
+            GraphAction::ZoomOut,
+            vec![KeyCombo::simple(KeyCode::Char('-'))],
+        );
+        graph.insert(
+            GraphAction::OpenNote,
+            vec![KeyCombo::simple(KeyCode::Enter)],
+        );
+        graph.insert(
+            GraphAction::ToggleLabels,
+            vec![KeyCombo::shift(KeyCode::Char('L'))],
+        );
+        graph.insert(
+            GraphAction::AutoFit,
+            vec![KeyCombo::simple(KeyCode::Char('a'))],
+        );
+        graph.insert(
+            GraphAction::Help,
+            vec![
+                KeyCombo::simple(KeyCode::Char('?')),
+                KeyCombo::simple(KeyCode::F(1)),
+            ],
+        );
+
+        Self {
+            list,
+            edit,
+            help,
+            graph,
+        }
     }
 }
 
@@ -561,6 +627,18 @@ impl Keybinds {
             }
         }
 
+        for (action_str, combos_str) in &toml.graph {
+            if let Some(action) = parse_graph_action(action_str) {
+                let combos: Vec<KeyCombo> = combos_str
+                    .iter()
+                    .filter_map(|s| KeyCombo::parse(s))
+                    .collect();
+                if !combos.is_empty() {
+                    keybinds.graph.insert(action, combos);
+                }
+            }
+        }
+
         Ok(keybinds)
     }
 
@@ -602,6 +680,12 @@ impl Keybinds {
             toml.help.insert(key.to_string(), values);
         }
 
+        for (action, combos) in &self.graph {
+            let key = graph_action_to_string(*action);
+            let values: Vec<String> = combos.iter().map(KeyCombo::to_display_string).collect();
+            toml.graph.insert(key.to_string(), values);
+        }
+
         toml
     }
 
@@ -622,6 +706,12 @@ impl Keybinds {
     /// Check if a key event matches a help action
     pub fn matches_help(&self, action: HelpAction, event: &KeyEvent) -> bool {
         self.help
+            .get(&action)
+            .is_some_and(|combos| combos.iter().any(|c| c.matches(event)))
+    }
+
+    pub fn matches_graph(&self, action: GraphAction, event: &KeyEvent) -> bool {
+        self.graph
             .get(&action)
             .is_some_and(|combos| combos.iter().any(|c| c.matches(event)))
     }
@@ -667,6 +757,19 @@ impl Keybinds {
             })
             .unwrap_or_default()
     }
+
+    pub fn graph_keys_display(&self, action: GraphAction) -> String {
+        self.graph
+            .get(&action)
+            .map(|combos| {
+                combos
+                    .iter()
+                    .map(KeyCombo::to_display_string)
+                    .collect::<Vec<_>>()
+                    .join("/")
+            })
+            .unwrap_or_default()
+    }
 }
 
 fn parse_list_action(s: &str) -> Option<ListAction> {
@@ -691,6 +794,7 @@ fn parse_list_action(s: &str) -> Option<ListAction> {
         "filter_tags" => Some(ListAction::FilterTags),
         "collapse_folder" => Some(ListAction::CollapseFolder),
         "expand_folder" => Some(ListAction::ExpandFolder),
+        "open_graph" => Some(ListAction::OpenGraph),
         _ => None,
     }
 }
@@ -721,6 +825,23 @@ fn parse_help_action(s: &str) -> Option<HelpAction> {
         "close" => Some(HelpAction::Close),
         "scroll_up" => Some(HelpAction::ScrollUp),
         "scroll_down" => Some(HelpAction::ScrollDown),
+        _ => None,
+    }
+}
+
+fn parse_graph_action(s: &str) -> Option<GraphAction> {
+    match s {
+        "quit" => Some(GraphAction::Quit),
+        "pan_up" => Some(GraphAction::PanUp),
+        "pan_down" => Some(GraphAction::PanDown),
+        "pan_left" => Some(GraphAction::PanLeft),
+        "pan_right" => Some(GraphAction::PanRight),
+        "zoom_in" => Some(GraphAction::ZoomIn),
+        "zoom_out" => Some(GraphAction::ZoomOut),
+        "open_note" => Some(GraphAction::OpenNote),
+        "toggle_labels" => Some(GraphAction::ToggleLabels),
+        "auto_fit" => Some(GraphAction::AutoFit),
+        "help" => Some(GraphAction::Help),
         _ => None,
     }
 }
@@ -760,6 +881,7 @@ fn list_action_to_string(action: ListAction) -> &'static str {
         ListAction::PageDown => "page_down",
         ListAction::OpenTrash => "open_trash",
         ListAction::TogglePreview => "toggle_preview",
+        ListAction::OpenGraph => "open_graph",
     }
 }
 
@@ -788,6 +910,22 @@ fn help_action_to_string(action: HelpAction) -> &'static str {
         HelpAction::Close => "close",
         HelpAction::ScrollUp => "scroll_up",
         HelpAction::ScrollDown => "scroll_down",
+    }
+}
+
+fn graph_action_to_string(action: GraphAction) -> &'static str {
+    match action {
+        GraphAction::Quit => "quit",
+        GraphAction::PanUp => "pan_up",
+        GraphAction::PanDown => "pan_down",
+        GraphAction::PanLeft => "pan_left",
+        GraphAction::PanRight => "pan_right",
+        GraphAction::ZoomIn => "zoom_in",
+        GraphAction::ZoomOut => "zoom_out",
+        GraphAction::OpenNote => "open_note",
+        GraphAction::ToggleLabels => "toggle_labels",
+        GraphAction::AutoFit => "auto_fit",
+        GraphAction::Help => "help",
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod config;
 pub mod constants;
 pub mod frontmatter;
 mod keybinds;
+pub mod markdown;
 pub mod sanitize;
 mod templates;
 pub mod actions;
@@ -726,7 +727,24 @@ fn run_app(
 
         terminal.draw(|frame| draw_ui(frame, app, focus))?;
 
-        if event::poll(Duration::from_millis(200)).context("event poll failed")? {
+        let poll_timeout = if app.preview_renderer.as_ref().map_or(false, |r| r.is_pending())
+            || app
+                .md_preview_renderer
+                .as_ref()
+                .map_or(false, |r| r.is_pending())
+        {
+            Duration::from_millis(50)
+        } else {
+            Duration::from_millis(200)
+        };
+
+        let need_redraw = app.poll_renderers();
+
+        if need_redraw {
+            terminal.draw(|frame| draw_ui(frame, app, focus))?;
+        }
+
+        if event::poll(poll_timeout).context("event poll failed")? {
             match event::read().context("failed to read event")? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => match app.mode {
                     ViewMode::List => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ pub mod actions;
 mod config;
 pub mod constants;
 pub mod frontmatter;
+pub mod graph;
 mod keybinds;
 pub mod markdown;
 pub mod palette;
@@ -725,7 +726,9 @@ fn run_app(
 
         terminal.draw(|frame| draw_ui(frame, app, focus))?;
 
-        let poll_timeout = if app
+        let poll_timeout = if app.mode == ViewMode::Graph {
+            Duration::from_millis(33)
+        } else if app
             .preview_renderer
             .as_ref()
             .map_or(false, |r| r.is_pending())
@@ -761,6 +764,9 @@ fn run_app(
                     ViewMode::Help => {
                         handle_help_keys(app, key);
                     }
+                    ViewMode::Graph => {
+                        crate::graph::input::handle_graph_keys(app, key);
+                    }
                 },
                 Event::Mouse(mouse_event) if app.mode == ViewMode::List => {
                     let size = terminal.size().context("failed to get terminal size")?;
@@ -790,6 +796,44 @@ fn run_app(
                             .as_ref()
                             .map_or(0, |t| t.height().saturating_sub(5) as u16);
                         app.help_scroll = app.help_scroll.saturating_add(3).min(max_scroll);
+                    }
+                }
+                Event::Mouse(mouse_event) if app.mode == ViewMode::Graph => {
+                    let size = terminal.size().context("failed to get terminal size")?;
+                    let area = Rect::new(0, 0, size.width, size.height);
+
+                    let was_click = matches!(
+                        mouse_event.kind,
+                        crossterm::event::MouseEventKind::Up(crossterm::event::MouseButton::Left)
+                    ) && app
+                        .graph_mouse_state
+                        .drag_origin
+                        .is_some_and(|(c, r)| c == mouse_event.column && r == mouse_event.row)
+                        && !app.graph_mouse_state.is_panning;
+
+                    if let Some(graph_state) = &app.graph_state {
+                        crate::graph::input::handle_graph_mouse(
+                            graph_state,
+                            mouse_event,
+                            area,
+                            &mut app.graph_mouse_state,
+                        );
+                    }
+
+                    if was_click {
+                        let note_id = app.graph_state.as_ref().and_then(|state| {
+                            let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                            guard.selected_node.and_then(|idx| {
+                                guard
+                                    .simulation
+                                    .get_graph()
+                                    .node_weight(idx)
+                                    .map(|n| n.data.note_id.clone())
+                            })
+                        });
+                        if let Some(id) = note_id {
+                            app.open_note_from_graph(&id);
+                        }
                     }
                 }
                 Event::Paste(data) if app.mode == ViewMode::Edit => match focus {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
+pub mod actions;
 mod config;
 pub mod constants;
 pub mod frontmatter;
 mod keybinds;
 pub mod markdown;
+pub mod palette;
 pub mod sanitize;
 mod templates;
-pub mod actions;
-pub mod palette;
 
 use crate::config::BootstrapConfig;
 use crate::keybinds::{EditAction, HelpAction, Keybinds, ListAction};
@@ -58,7 +58,6 @@ fn main() -> Result<()> {
         }
         CliCommand::QuickNote { content, title } => {
             let storage = Storage::init()?;
-            let bootstrap = config::BootstrapConfig::load().unwrap_or_default();
 
             let id = Uuid::new_v4().simple().to_string();
             let final_title = title.unwrap_or_else(|| "Quick Note".to_string());
@@ -71,31 +70,28 @@ fn main() -> Result<()> {
                 tags: Vec::new(),
             };
 
-            let ext = if bootstrap.encryption_enabled {
-                "bin"
-            } else {
-                "md"
-            };
+            let _saved_id = storage.save_note(&id, &note)?;
 
-            let _saved_id = storage.save_note(&id, &note, bootstrap.encryption_enabled)?;
-
-            println!("Created note: {} (ext: {})", final_title, ext);
+            println!("Created note: {}", final_title);
 
             Ok(())
         }
         CliCommand::NewAndOpen { title, template } => {
             let storage = Storage::init()?;
             let mut app = App::new(storage)?;
-            
+
             // Use provided title or default
             let final_title = title.unwrap_or_else(|| "New Note".to_string());
-            
+
             // Create note from template or default
             let (content, tags) = if let Some(tmpl_name) = template {
                 let template_manager = app.storage.template_manager();
                 if let Ok(templates) = template_manager.list() {
-                    if let Some(template_summary) = templates.into_iter().find(|t| t.name == tmpl_name) {
-                        if let Ok(template_data) = template_manager.load(&template_summary.filename) {
+                    if let Some(template_summary) =
+                        templates.into_iter().find(|t| t.name == tmpl_name)
+                    {
+                        if let Ok(template_data) = template_manager.load(&template_summary.filename)
+                        {
                             (template_data.content.template.clone(), Vec::new())
                         } else {
                             eprintln!("Failed to load template data: {tmpl_name}");
@@ -111,7 +107,7 @@ fn main() -> Result<()> {
             } else {
                 (String::new(), Vec::new())
             };
-            
+
             let id = Uuid::new_v4().simple().to_string();
             let note = Note {
                 title: final_title,
@@ -121,9 +117,9 @@ fn main() -> Result<()> {
                     .as_secs(),
                 tags,
             };
-            
-            let saved_id = app.storage.save_note(&id, &note, app.encryption_enabled)?;
-            
+
+            let saved_id = app.storage.save_note(&id, &note)?;
+
             app.editing_id = Some(saved_id.clone());
             app.refresh_notes()?;
             app.load_and_open_note(&saved_id);
@@ -268,8 +264,11 @@ fn main() -> Result<()> {
             let templates_dst = to.join("templates");
             if templates_src.exists() && templates_src.is_dir() {
                 fs::create_dir_all(&templates_dst)?;
-                let (m, s, _) =
-                    migrate_directory_with_conflict(&templates_src, &templates_dst, conflict_action)?;
+                let (m, s, _) = migrate_directory_with_conflict(
+                    &templates_src,
+                    &templates_dst,
+                    conflict_action,
+                )?;
                 migrated_count += m;
                 skipped_count += s;
             }
@@ -610,8 +609,7 @@ fn migrate_file_with_conflict(
                 return Ok((0, 1, new_action));
             }
             ConflictAction::Overwrite | ConflictAction::OverwriteAll => {
-                fs::copy(src, dst)
-                    .with_context(|| format!("failed to copy {}", src.display()))?;
+                fs::copy(src, dst).with_context(|| format!("failed to copy {}", src.display()))?;
                 println!("  Overwritten: {}", display_name);
                 let new_action = if matches!(action, ConflictAction::OverwriteAll) {
                     Some(ConflictAction::OverwriteAll)
@@ -727,7 +725,10 @@ fn run_app(
 
         terminal.draw(|frame| draw_ui(frame, app, focus))?;
 
-        let poll_timeout = if app.preview_renderer.as_ref().map_or(false, |r| r.is_pending())
+        let poll_timeout = if app
+            .preview_renderer
+            .as_ref()
+            .map_or(false, |r| r.is_pending())
             || app
                 .md_preview_renderer
                 .as_ref()
@@ -801,7 +802,7 @@ fn run_app(
                         app.editor.insert_str(data);
                         app.status = Cow::Borrowed("Pasted body text");
                     }
-                    EditFocus::EncryptionToggle | EditFocus::ExternalEditorToggle => {}
+                    EditFocus::ExternalEditorToggle => {}
                 },
                 _ => {}
             }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,315 @@
+use std::io::{Read, Write};
+use std::sync::mpsc;
+
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{Block, Widget},
+};
+
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tui_term::vt100;
+
+static GLOW_AVAILABLE: Lazy<AtomicBool> =
+    Lazy::new(|| AtomicBool::new(which::which("glow").is_ok()));
+
+pub fn glow_available() -> bool {
+    GLOW_AVAILABLE.load(Ordering::Relaxed)
+}
+
+struct RenderResult {
+    parser: vt100::Parser,
+    content_rows: u16,
+}
+
+enum RendererState {
+    Idle,
+    Pending(mpsc::Receiver<Option<RenderResult>>),
+    Ready,
+}
+
+pub struct MarkdownRenderer {
+    state: RendererState,
+    parser: vt100::Parser,
+    scroll_offset: u16,
+    content_rows: u16,
+}
+
+impl MarkdownRenderer {
+    pub fn new(cols: u16) -> Self {
+        let rows = 200;
+        Self {
+            state: RendererState::Idle,
+            parser: vt100::Parser::new(rows, cols, 0),
+            scroll_offset: 0,
+            content_rows: rows,
+        }
+    }
+
+    pub fn render(&mut self, content: &str, cols: u16) {
+        let estimated_rows = if content.is_empty() {
+            1
+        } else {
+            (content.lines().count() as u16).max(50).min(2000)
+        };
+
+        self.scroll_offset = 0;
+        self.content_rows = estimated_rows;
+
+        if content.is_empty() {
+            self.parser = vt100::Parser::new(1, cols, 0);
+            self.state = RendererState::Ready;
+            return;
+        }
+
+        let content_owned = content.to_owned();
+        let (tx, rx) = mpsc::channel();
+        self.state = RendererState::Pending(rx);
+
+        std::thread::spawn(move || {
+            let result = render_in_thread(&content_owned, cols, estimated_rows);
+            let _ = tx.send(result);
+        });
+    }
+
+    pub fn poll(&mut self) -> bool {
+        let rx = match &self.state {
+            RendererState::Pending(rx) => rx,
+            _ => return false,
+        };
+
+        match rx.try_recv() {
+            Ok(Some(result)) => {
+                self.parser = result.parser;
+                self.content_rows = result.content_rows;
+                self.state = RendererState::Ready;
+                true
+            }
+            Ok(None) => {
+                self.state = RendererState::Ready;
+                true
+            }
+            Err(mpsc::TryRecvError::Empty) => false,
+            Err(mpsc::TryRecvError::Disconnected) => {
+                self.state = RendererState::Ready;
+                true
+            }
+        }
+    }
+
+    pub fn is_pending(&self) -> bool {
+        matches!(self.state, RendererState::Pending(_))
+    }
+
+    pub fn screen(&self) -> &vt100::Screen {
+        self.parser.screen()
+    }
+
+    pub fn scroll_offset(&self) -> u16 {
+        self.scroll_offset
+    }
+
+    pub fn content_rows(&self) -> u16 {
+        self.content_rows
+    }
+
+    pub fn scroll_up(&mut self, n: u16) {
+        self.scroll_offset = self.scroll_offset.saturating_sub(n);
+    }
+
+    pub fn scroll_down(&mut self, n: u16, visible_rows: u16) {
+        let max = self.content_rows.saturating_sub(visible_rows);
+        self.scroll_offset = (self.scroll_offset + n).min(max);
+    }
+}
+
+fn render_in_thread(content: &str, cols: u16, estimated_rows: u16) -> Option<RenderResult> {
+    let mut parser = vt100::Parser::new(estimated_rows, cols, 0);
+
+    if !glow_available() {
+        process_fallback(&mut parser, content, estimated_rows);
+        return Some(RenderResult {
+            parser,
+            content_rows: estimated_rows,
+        });
+    }
+
+    let mut temp_file = tempfile::Builder::new()
+        .suffix(".md")
+        .prefix("clin_md_")
+        .tempfile()
+        .ok()?;
+
+    temp_file.write_all(content.as_bytes()).ok()?;
+    temp_file.flush().ok()?;
+
+    let temp_path = temp_file.path().to_owned();
+
+    let pty_system = NativePtySystem::default();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: estimated_rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .ok()?;
+
+    let mut cmd = CommandBuilder::new("glow");
+    cmd.arg("-w");
+    cmd.arg(cols.to_string());
+    cmd.arg("-s");
+    cmd.arg("dark");
+    cmd.arg(&temp_path);
+
+    let mut child = pair.slave.spawn_command(cmd).ok()?;
+    drop(pair.slave);
+
+    let mut reader = pair.master.try_clone_reader().ok()?;
+    let _writer = pair.master.take_writer();
+
+    let mut output = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => output.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+
+    let exit_ok = child.wait().map(|s| s.success()).unwrap_or(false);
+
+    drop(_writer);
+    drop(reader);
+    drop(pair.master);
+    drop(temp_file);
+
+    if !output.is_empty() && exit_ok {
+        parser.process(&output);
+    } else {
+        process_fallback(&mut parser, content, estimated_rows);
+    }
+
+    Some(RenderResult {
+        parser,
+        content_rows: estimated_rows,
+    })
+}
+
+fn process_fallback(parser: &mut vt100::Parser, content: &str, estimated_rows: u16) {
+    let mut fallback_output = Vec::new();
+    for line in content.lines().take((estimated_rows - 3) as usize) {
+        fallback_output.extend_from_slice(line.as_bytes());
+        fallback_output.push(b'\n');
+    }
+    fallback_output
+        .extend_from_slice(b"\n\x1b[38;5;242mInstall 'glow' for markdown rendering\x1b[0m\n");
+    parser.process(&fallback_output);
+}
+
+pub struct ScrollablePseudoTerminal<'a> {
+    screen: &'a vt100::Screen,
+    scroll_offset: u16,
+    block: Option<Block<'a>>,
+}
+
+impl<'a> ScrollablePseudoTerminal<'a> {
+    pub fn new(screen: &'a vt100::Screen) -> Self {
+        Self {
+            screen,
+            scroll_offset: 0,
+            block: None,
+        }
+    }
+
+    pub fn scroll_offset(mut self, offset: u16) -> Self {
+        self.scroll_offset = offset;
+        self
+    }
+
+    pub fn block(mut self, block: Block<'a>) -> Self {
+        self.block = Some(block);
+        self
+    }
+}
+
+impl Widget for ScrollablePseudoTerminal<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let inner = match &self.block {
+            Some(b) => {
+                let inner = b.inner(area);
+                b.clone().render(area, buf);
+                inner
+            }
+            None => area,
+        };
+
+        let cols = inner.width;
+        let rows = inner.height;
+        let col_start = inner.x;
+        let row_start = inner.y;
+
+        for row in 0..rows {
+            let screen_row = row + self.scroll_offset;
+            for col in 0..cols {
+                let buf_col = col + col_start;
+                let buf_row = row + row_start;
+                if let Some(screen_cell) = self.screen.cell(screen_row, col) {
+                    if screen_cell.has_contents() {
+                        let cell = &mut buf[(buf_col, buf_row)];
+                        cell.set_symbol(&screen_cell.contents());
+                    }
+                    let mut style = Style::reset();
+                    if screen_cell.bold() {
+                        style = style.add_modifier(Modifier::BOLD);
+                    }
+                    if screen_cell.italic() {
+                        style = style.add_modifier(Modifier::ITALIC);
+                    }
+                    if screen_cell.underline() {
+                        style = style.add_modifier(Modifier::UNDERLINED);
+                    }
+                    if screen_cell.inverse() {
+                        style = style.add_modifier(Modifier::REVERSED);
+                    }
+
+                    let fg = convert_color(screen_cell.fgcolor());
+                    let bg = convert_color(screen_cell.bgcolor());
+                    style = style.fg(fg).bg(bg);
+
+                    let cell = &mut buf[(buf_col, buf_row)];
+                    cell.set_style(style);
+                }
+            }
+        }
+    }
+}
+
+fn convert_color(value: vt100::Color) -> Color {
+    match value {
+        vt100::Color::Default => Color::Reset,
+        vt100::Color::Idx(0) => Color::Black,
+        vt100::Color::Idx(1) => Color::Red,
+        vt100::Color::Idx(2) => Color::Green,
+        vt100::Color::Idx(3) => Color::Yellow,
+        vt100::Color::Idx(4) => Color::Blue,
+        vt100::Color::Idx(5) => Color::Magenta,
+        vt100::Color::Idx(6) => Color::Cyan,
+        vt100::Color::Idx(7) => Color::Gray,
+        vt100::Color::Idx(8) => Color::DarkGray,
+        vt100::Color::Idx(9) => Color::LightRed,
+        vt100::Color::Idx(10) => Color::LightGreen,
+        vt100::Color::Idx(11) => Color::LightYellow,
+        vt100::Color::Idx(12) => Color::LightBlue,
+        vt100::Color::Idx(13) => Color::LightMagenta,
+        vt100::Color::Idx(14) => Color::LightCyan,
+        vt100::Color::Idx(15) => Color::White,
+        vt100::Color::Idx(i) => Color::Indexed(i),
+        vt100::Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
+    }
+}

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -165,6 +165,7 @@ fn render_in_thread(content: &str, cols: u16, estimated_rows: u16) -> Option<Ren
     cmd.arg("-s");
     cmd.arg("dark");
     cmd.arg(&temp_path);
+    cmd.env("TERM", "dumb");
 
     let mut child = pair.slave.spawn_command(cmd).ok()?;
     drop(pair.slave);

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -53,8 +53,8 @@ impl CommandPalette {
                 });
             }
         } else {
-            use fuzzy_matcher::skim::SkimMatcherV2;
             use fuzzy_matcher::FuzzyMatcher;
+            use fuzzy_matcher::skim::SkimMatcherV2;
             let matcher = SkimMatcherV2::default();
             for action in actions {
                 if let Some(score) = matcher.fuzzy_match(&action.name, query) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -45,8 +45,7 @@ pub struct NoteSummary {
     pub pinned: bool,
 }
 
-#[derive(Clone, Debug)]
-#[derive(zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+#[derive(Clone, Debug, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
 pub struct Storage {
     #[zeroize(skip)]
     pub data_dir: PathBuf,
@@ -95,7 +94,6 @@ impl Storage {
         let key = if key_path.exists() {
             #[cfg(unix)]
             {
-                // Enforce permissions on existing key file
                 use std::os::unix::fs::PermissionsExt;
                 if let Ok(metadata) = fs::metadata(&key_path) {
                     let mut perms = metadata.permissions();
@@ -114,29 +112,7 @@ impl Storage {
             key.copy_from_slice(&raw);
             key
         } else {
-            let mut key = [0_u8; 32];
-            rand::rngs::OsRng.fill_bytes(&mut key);
-            fs::create_dir_all(&data_dir).context("failed to create app data directory")?;
-            
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::OpenOptionsExt;
-                let mut file = std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .mode(0o400)
-                    .open(&key_path)
-                    .context("failed to create encryption key file")?;
-                use std::io::Write;
-                file.write_all(&key).context("failed to write encryption key")?;
-            }
-            
-            #[cfg(not(unix))]
-            {
-                fs::write(&key_path, key).context("failed to write encryption key")?;
-            }
-            
-            key
+            [0_u8; 32]
         };
 
         Ok(Self {
@@ -146,6 +122,149 @@ impl Storage {
             templates_dir,
             key,
         })
+    }
+
+    fn key_path(&self) -> PathBuf {
+        self.data_dir.join("key.bin")
+    }
+
+    pub fn ensure_key(&mut self) -> Result<()> {
+        if self.key != [0_u8; 32] {
+            return Ok(());
+        }
+
+        let key_path = self.key_path();
+        if key_path.exists() {
+            let raw = fs::read(&key_path).context("failed to read encryption key")?;
+            if raw.len() != 32 {
+                anyhow::bail!("invalid key file length");
+            }
+            self.key.copy_from_slice(&raw);
+            return Ok(());
+        }
+
+        rand::rngs::OsRng.fill_bytes(&mut self.key);
+        fs::create_dir_all(&self.data_dir).context("failed to create app data directory")?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o400)
+                .open(&key_path)
+                .context("failed to create encryption key file")?;
+            use std::io::Write;
+            file.write_all(&self.key)
+                .context("failed to write encryption key")?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            fs::write(&key_path, self.key).context("failed to write encryption key")?;
+        }
+
+        Ok(())
+    }
+
+    pub fn encrypt_note(&mut self, id: &str) -> Result<String> {
+        if id.ends_with(".clin") {
+            anyhow::bail!("Note is already encrypted");
+        }
+
+        self.ensure_key()?;
+
+        let note = self.load_note(id)?;
+        let old_path = self.note_path(id);
+
+        let folder = if let Some(idx) = id.rfind('/') {
+            &id[..idx]
+        } else {
+            ""
+        };
+
+        let stem = old_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("Untitled note");
+        let clin_id = if folder.is_empty() {
+            format!("{}.clin", stem)
+        } else {
+            format!("{}/{}.clin", folder, stem)
+        };
+        let target_id = self.unique_note_id(stem, "clin", &clin_id);
+        let target_path = self.note_path(&target_id);
+
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).unwrap_or_default();
+        }
+
+        let fm = frontmatter::Frontmatter {
+            tags: note.tags.clone(),
+            pinned: false,
+        };
+        let bytes = bincode::serde::encode_to_vec(&note, bincode::config::standard())
+            .context("failed to encode note")?;
+        let encrypted = self.encrypt(&bytes)?;
+        let fm_string = frontmatter::serialize(&fm, "");
+        let mut final_output = fm_string.into_bytes();
+        final_output.extend_from_slice(&encrypted);
+
+        fs::write(&target_path, final_output).context("failed to write encrypted note")?;
+
+        if old_path.exists() {
+            fs::remove_file(&old_path).context("failed to remove plain note after encryption")?;
+        }
+
+        Ok(target_id)
+    }
+
+    pub fn decrypt_note(&mut self, id: &str) -> Result<String> {
+        if !id.ends_with(".clin") {
+            anyhow::bail!("Note is not encrypted");
+        }
+
+        self.ensure_key()?;
+
+        let note = self.load_note(id)?;
+        let old_path = self.note_path(id);
+
+        let folder = if let Some(idx) = id.rfind('/') {
+            &id[..idx]
+        } else {
+            ""
+        };
+
+        let stem = old_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("Untitled note");
+        let md_id = if folder.is_empty() {
+            format!("{}.md", stem)
+        } else {
+            format!("{}/{}.md", folder, stem)
+        };
+        let target_id = self.unique_note_id(stem, "md", &md_id);
+        let target_path = self.note_path(&target_id);
+
+        if let Some(parent) = target_path.parent() {
+            fs::create_dir_all(parent).unwrap_or_default();
+        }
+
+        let fm = frontmatter::Frontmatter {
+            tags: note.tags.clone(),
+            pinned: false,
+        };
+        let final_content = frontmatter::serialize(&fm, &note.content);
+        fs::write(&target_path, final_content).context("failed to write decrypted note")?;
+
+        if old_path.exists() {
+            fs::remove_file(&old_path)
+                .context("failed to remove encrypted note after decryption")?;
+        }
+
+        Ok(target_id)
     }
 
     pub fn keybinds_path(&self) -> PathBuf {
@@ -308,15 +427,13 @@ impl Storage {
         }
     }
 
-    pub fn save_note(&self, id: &str, note: &Note, encryption_enabled: bool) -> Result<String> {
+    pub fn save_note(&self, id: &str, note: &Note) -> Result<String> {
         let preferred_stem = self.note_file_stem_from_title(&note.title);
 
         let old_path = self.note_path(id);
         let old_ext = old_path.extension().and_then(|e| e.to_str()).unwrap_or("");
 
-        let target_ext = if encryption_enabled {
-            "clin"
-        } else if old_ext == "txt" || old_ext == "md" {
+        let target_ext = if old_ext == "clin" || old_ext == "txt" || old_ext == "md" {
             old_ext
         } else {
             "md"
@@ -373,8 +490,8 @@ impl Storage {
             .unwrap()
             .as_secs();
 
-        let is_encrypted = id.ends_with(".clin");
-        self.save_note(id, &note, is_encrypted)
+        let _is_encrypted = id.ends_with(".clin");
+        self.save_note(id, &note)
     }
 
     /// Duplicate a note with a new title
@@ -403,10 +520,15 @@ impl Storage {
         let initial_id = if folder.is_empty() {
             format!("{}.{}", new_id, if is_encrypted { "clin" } else { "md" })
         } else {
-            format!("{}/{}.{}", folder, new_id, if is_encrypted { "clin" } else { "md" })
+            format!(
+                "{}/{}.{}",
+                folder,
+                new_id,
+                if is_encrypted { "clin" } else { "md" }
+            )
         };
 
-        self.save_note(&initial_id, &new_note, is_encrypted)
+        self.save_note(&initial_id, &new_note)
     }
 
     pub fn trash_note(&self, id: &str) -> Result<()> {
@@ -419,8 +541,8 @@ impl Storage {
     }
 
     pub fn list_trash(&self) -> Result<Vec<trash::TrashItem>> {
-        let items = trash::os_limited::list()
-            .map_err(|e| anyhow::anyhow!("failed to list trash: {e}"))?;
+        let items =
+            trash::os_limited::list().map_err(|e| anyhow::anyhow!("failed to list trash: {e}"))?;
         let vault_items: Vec<trash::TrashItem> = items
             .into_iter()
             .filter(|item| item.original_parent.starts_with(&self.notes_dir))
@@ -435,8 +557,7 @@ impl Storage {
     }
 
     pub fn purge_trash_items(&self, items: Vec<trash::TrashItem>) -> Result<()> {
-        trash::os_limited::purge_all(items)
-            .map_err(|e| anyhow::anyhow!("failed to purge: {e}"))?;
+        trash::os_limited::purge_all(items).map_err(|e| anyhow::anyhow!("failed to purge: {e}"))?;
         Ok(())
     }
 
@@ -481,19 +602,22 @@ impl Storage {
     }
 
     pub fn create_folder(&self, path: &str) -> Result<()> {
-        let full_path = self.validate_path_within_notes_dir(path)
+        let full_path = self
+            .validate_path_within_notes_dir(path)
             .ok_or_else(|| anyhow::anyhow!("Invalid folder path"))?;
         fs::create_dir_all(full_path).context("failed to create folder")
     }
 
     pub fn delete_folder(&self, path: &str) -> Result<()> {
-        let full_path = self.validate_path_within_notes_dir(path)
+        let full_path = self
+            .validate_path_within_notes_dir(path)
             .ok_or_else(|| anyhow::anyhow!("Invalid folder path"))?;
         fs::remove_dir_all(full_path).context("failed to delete folder")
     }
 
     pub fn trash_folder(&self, path: &str) -> Result<()> {
-        let full_path = self.validate_path_within_notes_dir(path)
+        let full_path = self
+            .validate_path_within_notes_dir(path)
             .ok_or_else(|| anyhow::anyhow!("Invalid folder path"))?;
         if !full_path.exists() {
             anyhow::bail!("Folder does not exist");
@@ -503,9 +627,11 @@ impl Storage {
     }
 
     pub fn rename_folder(&self, old_path: &str, new_path: &str) -> Result<()> {
-        let old_full = self.validate_path_within_notes_dir(old_path)
+        let old_full = self
+            .validate_path_within_notes_dir(old_path)
             .ok_or_else(|| anyhow::anyhow!("Invalid source folder path"))?;
-        let new_full = self.validate_path_within_notes_dir(new_path)
+        let new_full = self
+            .validate_path_within_notes_dir(new_path)
             .ok_or_else(|| anyhow::anyhow!("Invalid target folder path"))?;
 
         if !old_full.exists() {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -74,6 +74,7 @@ pub fn help_page_text(keybinds: &Keybinds) -> Text<'static> {
     let edit_redo = keybinds.edit_keys_display(EditAction::Redo);
     let edit_del_word = keybinds.edit_keys_display(EditAction::DeleteWord);
     let edit_del_next_word = keybinds.edit_keys_display(EditAction::DeleteNextWord);
+    let edit_md_preview = keybinds.edit_keys_display(EditAction::ToggleMarkdownPreview);
 
     let help_close = keybinds.help_keys_display(HelpAction::Close);
     let help_scroll = format!(
@@ -174,6 +175,10 @@ pub fn help_page_text(keybinds: &Keybinds) -> Text<'static> {
     lines.extend(help_item_dyn(
         "Delete prev/next word",
         Some(&format!("{edit_del_word} / {edit_del_next_word}")),
+    ));
+    lines.extend(help_item_dyn(
+        "Toggle markdown preview",
+        Some(&edit_md_preview),
     ));
     lines.push(Line::from(""));
 
@@ -396,18 +401,36 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
 
     // Render preview pane if enabled
     if let Some(preview_rect) = preview_area {
-        let preview_text = app
-            .preview_content
-            .as_deref()
-            .unwrap_or("Select a note to preview");
-        let preview = Paragraph::new(preview_text)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title("Preview (Shift+P to close)"),
-            )
-            .wrap(ratatui::widgets::Wrap { trim: false });
-        frame.render_widget(preview, preview_rect);
+        match &app.preview_renderer {
+            Some(renderer) if !renderer.is_pending() => {
+                let widget = crate::markdown::ScrollablePseudoTerminal::new(renderer.screen())
+                    .scroll_offset(renderer.scroll_offset())
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title("Preview (Shift+P to close)"),
+                    );
+                frame.render_widget(widget, preview_rect);
+            }
+            Some(_) => {
+                let loading = Paragraph::new("Rendering preview...")
+                    .style(Style::default().fg(Color::DarkGray))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title("Preview (Shift+P to close)"),
+                    );
+                frame.render_widget(loading, preview_rect);
+            }
+            None => {
+                let placeholder = Paragraph::new("Select a note to preview").block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title("Preview (Shift+P to close)"),
+                );
+                frame.render_widget(placeholder, preview_rect);
+            }
+        }
     }
 
     let enc_button_label = if app.encryption_enabled {
@@ -766,7 +789,6 @@ pub fn draw_edit_view(frame: &mut Frame, app: &mut App, focus: EditFocus) {
         ])
         .split(area);
 
-    // Set block directly on app's editor to avoid clone
     let title_border = if focus == EditFocus::Title {
         Style::default().fg(Color::Yellow)
     } else {
@@ -792,19 +814,72 @@ pub fn draw_edit_view(frame: &mut Frame, app: &mut App, focus: EditFocus) {
         frame.render_widget(placeholder, title_inner);
     }
 
-    // Set block directly on app's editor to avoid clone
-    let body_border = if focus == EditFocus::Body {
-        Style::default().fg(Color::Yellow)
+    if app.markdown_preview_enabled {
+        let content_chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(chunks[1]);
+
+        let body_border = if focus == EditFocus::Body {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default()
+        };
+        app.editor.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(body_border)
+                .title("Content"),
+        );
+        frame.render_widget(&app.editor, content_chunks[0]);
+
+        match &app.md_preview_renderer {
+            Some(renderer) if !renderer.is_pending() => {
+                let md_widget = crate::markdown::ScrollablePseudoTerminal::new(renderer.screen())
+                    .scroll_offset(renderer.scroll_offset())
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(Color::Cyan))
+                            .title("Markdown Preview (Ctrl+P)"),
+                    );
+                frame.render_widget(md_widget, content_chunks[1]);
+            }
+            Some(_) => {
+                let loading = Paragraph::new("Rendering preview...")
+                    .style(Style::default().fg(Color::DarkGray))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .border_style(Style::default().fg(Color::Cyan))
+                            .title("Markdown Preview (Ctrl+P)"),
+                    );
+                frame.render_widget(loading, content_chunks[1]);
+            }
+            None => {
+                let placeholder = Paragraph::new("Press Ctrl+P to render preview").block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Cyan))
+                        .title("Markdown Preview (Ctrl+P)"),
+                );
+                frame.render_widget(placeholder, content_chunks[1]);
+            }
+        }
     } else {
-        Style::default()
-    };
-    app.editor.set_block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(body_border)
-            .title("Content"),
-    );
-    frame.render_widget(&app.editor, chunks[1]);
+        let body_border = if focus == EditFocus::Body {
+            Style::default().fg(Color::Yellow)
+        } else {
+            Style::default()
+        };
+        app.editor.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(body_border)
+                .title("Content"),
+        );
+        frame.render_widget(&app.editor, chunks[1]);
+    }
 
     let enc_button_label = if app.encryption_enabled {
         "[ Enc: ON ]"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -346,16 +346,12 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
                     ));
                 }
 
-                if !is_clin {
+                if *is_clin {
+                    text_style = text_style.fg(Color::DarkGray);
                     spans.push(Span::styled(
-                        "[UENC] ",
-                        Style::default()
-                            .fg(Color::Yellow)
-                            .add_modifier(Modifier::BOLD),
+                        "\u{f023} ",
+                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                     ));
-                } else if !app.encryption_enabled {
-                    text_style = text_style.fg(Color::Red);
-                    spans.push(Span::styled("[ENC] ", text_style));
                 }
 
                 let sanitized_title =
@@ -433,24 +429,6 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
         }
     }
 
-    let enc_button_label = if app.encryption_enabled {
-        "[ Enc: ON ]"
-    } else {
-        "[ Enc: OFF ]"
-    };
-    let enc_button_style = if app.list_focus == ListFocus::EncryptionToggle {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else if app.encryption_enabled {
-        Style::default()
-            .fg(Color::Green)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-    };
-
     let ext_button_label = if app.external_editor_enabled {
         "[ Ext: ON ]"
     } else {
@@ -470,8 +448,6 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
     };
 
     let footer_line = Line::from(vec![
-        Span::styled(enc_button_label, enc_button_style),
-        Span::raw(" "),
         Span::styled(ext_button_label, ext_button_style),
         Span::raw("   "),
         Span::raw(crate::sanitize::sanitize_for_terminal(app.status.as_ref())),
@@ -881,24 +857,6 @@ pub fn draw_edit_view(frame: &mut Frame, app: &mut App, focus: EditFocus) {
         frame.render_widget(&app.editor, chunks[1]);
     }
 
-    let enc_button_label = if app.encryption_enabled {
-        "[ Enc: ON ]"
-    } else {
-        "[ Enc: OFF ]"
-    };
-    let enc_button_style = if focus == EditFocus::EncryptionToggle {
-        Style::default()
-            .fg(Color::Black)
-            .bg(Color::Yellow)
-            .add_modifier(Modifier::BOLD)
-    } else if app.encryption_enabled {
-        Style::default()
-            .fg(Color::Green)
-            .add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
-    };
-
     let ext_button_label = if app.external_editor_enabled {
         "[ Ext: ON ]"
     } else {
@@ -918,8 +876,6 @@ pub fn draw_edit_view(frame: &mut Frame, app: &mut App, focus: EditFocus) {
     };
 
     let status_line = Line::from(vec![
-        Span::styled(enc_button_label, enc_button_style),
-        Span::raw(" "),
         Span::styled(ext_button_label, ext_button_style),
         Span::raw("   "),
         Span::raw(crate::sanitize::sanitize_for_terminal(app.status.as_ref())),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,6 +16,12 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App, focus: EditFocus) {
         ViewMode::List => draw_list_view(frame, app),
         ViewMode::Edit => draw_edit_view(frame, app, focus),
         ViewMode::Help => draw_help_view(frame, app),
+        ViewMode::Graph => {
+            if let Some(state) = &app.graph_state {
+                let guard = state.read().unwrap_or_else(|e| e.into_inner());
+                crate::graph::render::draw_graph_view(frame, &guard);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# ADD
- Graph view similar to Obsidian's graph view
- Proper markdown rendering using `glow`
- Note decrypting

# CHANGES
- Encryption is now on-demand which means user can encrypt/decrypt their nodes using command palette
- Read/write operations on encrypted notes are impossible now due to design change of the encryption system, these changes are made for the planned git integration for cloud storage

# FIXES/IMPROVEMENTS
- Increased code modularity in preparation for customizable user configs
- General code optimizations, especially markdown rendering should work 10x faster than before(when `glow` first implemented)
- UI improvements with more glyphs
- Removed [ENC] toggle button
- Removed config options for encryption
- Removed most dead vim and encryption related code blocks, functions
- Fixed issue #23 