### PR TITLE
docs: align MSRV references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for considering contributing to clin! Here's how to get started.
 ## Getting Started
 
 1. Fork and clone the repository
-2. Install Rust 1.85.0+ via [rustup](https://rustup.rs)
+2. Install Rust 1.88.0+ via [rustup](https://rustup.rs)
 3. Build: `cargo build`
 4. Run: `cargo run`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![CI](https://github.com/reekta92/clin-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/reekta92/clin-rs/actions/workflows/ci.yml)
 [![Release](https://github.com/reekta92/clin-rs/actions/workflows/dispatch-release.yml/badge.svg)](https://github.com/reekta92/clin-rs/actions/workflows/dispatch-release.yml)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
-[![MSRV: 1.88.0](https://img.shields.io/badge/MSRV-1.88.0-orange.svg)](https://blog.rust-lang.org/2024/09/19/Rust-1.81.0.html)
+[![MSRV: 1.88.0](https://img.shields.io/badge/MSRV-1.88.0-orange.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 
 </div>
 


### PR DESCRIPTION
## Summary
- update the README MSRV badge link to the Rust 1.88.0 announcement
- align CONTRIBUTING.md with the package rust-version of 1.88.0

## Validation
- git diff --check