### PR TITLE
Add Nix flake packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /dev_scripts/
 /info/
 /graphify-out/
+
+# Nix build results
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -134,6 +134,46 @@ makepkg -si
 yay -S clin-rs-bin
 ```
 
+### Nix
+
+#### Try it without installing
+```bash
+nix run github:reekta92/clin-rs
+```
+
+#### Build from source
+```bash
+git clone https://github.com/reekta92/clin-rs.git
+cd clin-rs
+nix build
+./result/bin/clin
+```
+
+#### NixOS / home-manager (flakes)
+
+Add this repo as a flake input:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    clin.url = "github:reekta92/clin-rs";
+  };
+
+  outputs = { self, nixpkgs, clin, ... }: {
+    # ... your existing outputs
+  };
+}
+```
+
+Then add the package to your system, e.g.:
+
+```nix
+environment.systemPackages = [
+  clin.packages.${pkgs.stdenv.hostPlatform.system;}.default
+];
+```
+
 ### AppImage
 Download the latest `.AppImage` from the [Releases](https://github.com/reekta92/clin-rs/releases) page.
 ```bash

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "clin-rs";
+  version = (lib.importTOML ./Cargo.toml).package.version;
+  src = ./.;
+
+  cargoHash = "sha256-x+7xlo7ovstn28Z1xGDmrj9o2KoiucKL+BQ+dYJWbFI=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "TUI note management app, a terminal reimplementation of Obsidian";
+    homepage = "https://github.com/reekta92/clin-rs";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
+    mainProgram = "clin";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781074563,
+        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "clin - A TUI reimagination of Obsidian";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.callPackage ./default.nix { };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${system}.default ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Adds flake.nix and default.nix to allow installing and developing clin via Nix (nix build, nix run, nix develop).

default.nix builds from the local source tree (src = ./.) via rustPlatform.buildRustPackage, and requires pkg-config + openssl for the openssl-sys dependency. flake.nix wraps it as the default package and provides a matching devShell.

## What
Adds `flake.nix` and `default.nix` to allow installing and developing clin via Nix (`nix build`, `nix run`, `nix develop`), plus a Nix install section in the README.

## Why
Lets Nix/NixOS users install clin declaratively or try it via `nix run`, without needing cargo or manual dependency setup.

## How
- `default.nix` builds the package via `rustPlatform.buildRustPackage`, using the local source tree (`src = ./.`)
- Requires `pkg-config` and `openssl` as build inputs for the `openssl-sys` dependency
- `flake.nix` wraps `default.nix` as the default package output and provides a matching `devShell`
- README gains a Nix section covering `nix run`, building from source, and flake input usage for NixOS/home-manager

**Maintenance note**: `cargoHash` in `default.nix` is derived from the vendored `Cargo.lock` dependencies. Any future `cargo update` or dependency change will require recomputing this hash — `nix build` reports the correct value on mismatch.

## Checklist
- [x] `cargo check` passes
- [x] `cargo test` passes (31/31)
- [ ] `cargo clippy -- -D warnings` — not run locally due to a clippy/rustc version
      mismatch in my Nix environment (system clippy 1.96.0 vs. project rustc 1.95.0);
      cargo check confirms no compile errors, CI should run clippy with a
      consistent toolchain
- [x] Documentation updated (README Nix section added)
