### PR TITLE
Add macOS ARM build to release workflow

### DIFF
--- a/.github/workflows/dispatch-release.yml
+++ b/.github/workflows/dispatch-release.yml
@@ -197,7 +197,37 @@ jobs:
         run: gh release upload "$TAG" dist/* --clobber
 
   # ────────────────────────────────────────────
-  # 4. Build .deb and .rpm
+  # 4. Build macOS ARM (Apple Silicon) binary
+  # ────────────────────────────────────────────
+  macos-arm:
+    needs: prepare
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: "v${{ needs.prepare.outputs.new_version }}"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --release --locked --target aarch64-apple-darwin
+      - name: Smoke test
+        run: ./target/aarch64-apple-darwin/release/clin -h
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp target/aarch64-apple-darwin/release/clin .
+          tar -cJf "dist/clin-rs-aarch64-apple-darwin.tar.xz" clin LICENSE README.md
+          tar -czf "dist/clin-rs-aarch64-apple-darwin.tar.gz" clin LICENSE README.md
+      - name: Upload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: "v${{ needs.prepare.outputs.new_version }}"
+        run: gh release upload "$TAG" dist/* --clobber
+
+  # ────────────────────────────────────────────
+  # 5. Build .deb and .rpm
   # ────────────────────────────────────────────
   linux-packages:
     needs: prepare
@@ -225,7 +255,7 @@ jobs:
         run: gh release upload "$TAG" target/debian/*.deb target/generate-rpm/*.rpm --clobber
 
   # ────────────────────────────────────────────
-  # 5. Build AppImage
+  # 6. Build AppImage
   # ────────────────────────────────────────────
   appimage:
     needs: prepare
@@ -265,7 +295,7 @@ jobs:
 
 
   # ────────────────────────────────────────────
-  # 6. Build Nix package
+  # 7. Build Nix package
   # ────────────────────────────────────────────
   nix:
     needs: prepare
@@ -281,7 +311,7 @@ jobs:
         run: nix build .#default
 
   # ────────────────────────────────────────────
-  # 7. Publish AUR package
+  # 8. Publish AUR package
   # ────────────────────────────────────────────
   aur:
     needs: [prepare, linux-packages, linux-x86_64]
@@ -332,7 +362,7 @@ jobs:
 
 
   # ────────────────────────────────────────────
-  # 8. Publish to crates.io
+  # 9. Publish to crates.io
   # ────────────────────────────────────────────
   crates-io:
     needs: prepare
@@ -353,7 +383,7 @@ jobs:
 
 
   # ────────────────────────────────────────────
-  # 9. Update README + PKGBUILD in main
+  # 10. Update README + PKGBUILD in main
   # ────────────────────────────────────────────
   post-release:
     needs: [prepare, linux-packages, appimage, linux-x86_64, nix]


### PR DESCRIPTION
This pull request updates the GitHub Actions release workflow to add support for building and packaging a native Apple Silicon (macOS ARM) binary, and renumbers the subsequent release steps accordingly. The main improvement is the introduction of a dedicated job for macOS ARM, ensuring official binaries are available for Apple Silicon users.

**New platform support:**

* Added a `macos-arm` job to build, test, package, and upload a native `aarch64-apple-darwin` (Apple Silicon) binary for macOS. This includes smoke testing and packaging into `.tar.xz` and `.tar.gz` archives.

**Workflow organization:**

* Incremented the numbering of all subsequent jobs to accommodate the new macOS ARM build step:
  - `.deb` and `.rpm` packaging is now step 5.
  - AppImage build is now step 6.
  - Nix package build is now step 7.
  - AUR package publish is now step 8.
  - crates.io publish is now step 9.
  - Post-release updates (README + PKGBUILD) are now step 10.## What

