### PR TITLE
Hotfix/vault

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -74,6 +74,7 @@ pub static ACTIONS: std::sync::LazyLock<Vec<Box<dyn Action>>> = std::sync::LazyL
         Box::new(settings::ToggleConfirmQuitAction),
         Box::new(settings::TogglePreviewEncryptionAction),
         Box::new(settings::CycleSortAction),
+        Box::new(settings::ToggleShowHiddenFilesAction),
         Box::new(import::ImportAction {
             source: crate::popups::ImportSource::File,
             target: crate::popups::ImportTarget::NewNote,

--- a/src/actions/settings.rs
+++ b/src/actions/settings.rs
@@ -219,3 +219,31 @@ impl Action for CycleSortAction {
         format!("Sort Order: {sort_desc}")
     }
 }
+
+pub struct ToggleShowHiddenFilesAction;
+
+impl Action for ToggleShowHiddenFilesAction {
+    fn id(&self) -> Cow<'static, str> {
+        Cow::Borrowed("settings.show_hidden_files")
+    }
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Show Hidden Files")
+    }
+    fn description(&self) -> Cow<'static, str> {
+        Cow::Borrowed("Show files and directories starting with '.' in the notes list")
+    }
+    fn category(&self) -> ActionCategory {
+        ActionCategory::Settings
+    }
+    fn glyph(&self) -> &'static str {
+        "\u{f06e}" // fa-eye (Nerd Fonts)
+    }
+    fn execute(&self, app: &mut App, _context_note_id: Option<&str>) -> Result<()> {
+        app.toggle_show_hidden_files();
+        Ok(())
+    }
+    fn name_dynamic(&self, app: &App) -> String {
+        let state = if app.list.show_hidden_files { "On" } else { "Off" };
+        format!("Show Hidden Files [{state}]")
+    }
+}

--- a/src/actions/settings.rs
+++ b/src/actions/settings.rs
@@ -243,7 +243,11 @@ impl Action for ToggleShowHiddenFilesAction {
         Ok(())
     }
     fn name_dynamic(&self, app: &App) -> String {
-        let state = if app.list.show_hidden_files { "On" } else { "Off" };
+        let state = if app.list.show_hidden_files {
+            "On"
+        } else {
+            "Off"
+        };
         format!("Show Hidden Files [{state}]")
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -337,6 +337,7 @@ impl App {
         list.list_density = bootstrap_config.list.density.clone();
         list.show_file_size = bootstrap_config.list.show_file_size;
         list.show_date_in_list = bootstrap_config.list.show_date_in_list;
+        list.show_hidden_files = bootstrap_config.list.show_hidden_files;
 
         let mut app = Self {
             storage,
@@ -386,7 +387,7 @@ impl App {
     }
 
     pub fn refresh_notes(&mut self) -> Result<()> {
-        let ids = self.storage.list_note_ids()?;
+        let ids = self.storage.list_note_ids(self.list.show_hidden_files)?;
         let mut summaries = Vec::new();
 
         for id in &ids {
@@ -507,7 +508,7 @@ impl App {
         let all_folders = if let Some(ref cache) = self.list.folder_cache {
             cache
         } else {
-            let folders = self.storage.list_folders().unwrap_or_default();
+            let folders = self.storage.list_folders(self.list.show_hidden_files).unwrap_or_default();
             self.list.folder_cache = Some(folders);
             self.list
                 .folder_cache
@@ -1946,7 +1947,7 @@ template = """
             self.list.visual_list.get(self.list.visual_index)
         {
             let note = &self.notes[*summary_idx];
-            if let Ok(folders) = self.storage.list_folders() {
+            if let Ok(folders) = self.storage.list_folders(self.list.show_hidden_files) {
                 let mut all_folders = vec!["".to_string()];
                 all_folders.extend(folders);
                 let mut input = TextArea::default();
@@ -1979,7 +1980,7 @@ template = """
                 return;
             }
             let folder_path = path.clone();
-            if let Ok(folders) = self.storage.list_folders() {
+            if let Ok(folders) = self.storage.list_folders(self.list.show_hidden_files) {
                 let mut all_folders = vec!["".to_string()];
                 all_folders.extend(
                     folders.into_iter().filter(|f| {
@@ -2016,7 +2017,7 @@ template = """
             }
 
             if !note_ids.is_empty()
-                && let Ok(folders) = self.storage.list_folders()
+                && let Ok(folders) = self.storage.list_folders(self.list.show_hidden_files)
             {
                 let mut all_folders = vec!["".to_string()];
                 all_folders.extend(folders);
@@ -2291,7 +2292,7 @@ template = """
     pub fn begin_delete_tag_with_name(&mut self, tag: String) {
         let count = self
             .storage
-            .list_note_ids()
+            .list_note_ids(self.list.show_hidden_files)
             .ok()
             .map(|ids| {
                 ids.iter()
@@ -2323,7 +2324,7 @@ template = """
 
     pub fn confirm_delete_tag(&mut self, tag: String) {
         let mut count = 0;
-        if let Ok(note_ids) = self.storage.list_note_ids() {
+        if let Ok(note_ids) = self.storage.list_note_ids(self.list.show_hidden_files) {
             for note_id in note_ids {
                 let ext = std::path::Path::new(&note_id)
                     .extension()
@@ -3035,7 +3036,7 @@ template = """
             self.list.visual_list.get(self.list.visual_index)
         {
             let id = self.notes[*summary_idx].id.clone();
-            if let Ok(folders) = self.storage.list_folders() {
+            if let Ok(folders) = self.storage.list_folders(self.list.show_hidden_files) {
                 let mut all_folders = vec!["".to_string()];
                 all_folders.extend(folders);
                 let mut input = ratatui_textarea::TextArea::default();
@@ -3756,7 +3757,7 @@ template = """
                 let all_folders = if let Some(ref cache) = self.list.folder_cache {
                     cache.clone()
                 } else {
-                    let folders = self.storage.list_folders().unwrap_or_default();
+                    let folders = self.storage.list_folders(self.list.show_hidden_files).unwrap_or_default();
                     self.list.folder_cache = Some(folders.clone());
                     folders
                 };
@@ -3948,6 +3949,26 @@ template = """
         self.set_temporary_status_static(msg);
         if let Ok(mut config) = crate::config::ClinConfig::load() {
             config.list.pinned_on_top = self.pinned_on_top;
+            if let Err(e) = config.save() {
+                self.set_temporary_status(&format!("Failed to save config: {e}"));
+            }
+        }
+    }
+
+    pub fn toggle_show_hidden_files(&mut self) {
+        self.list.show_hidden_files = !self.list.show_hidden_files;
+        self.list.folder_cache = None; // invalidate cached folder list
+        if let Err(e) = self.refresh_notes() {
+            self.set_temporary_status(&format!("Refresh failed: {e}"));
+        }
+        let msg: &'static str = if self.list.show_hidden_files {
+            "Hidden files shown"
+        } else {
+            "Hidden files hidden"
+        };
+        self.set_temporary_status_static(msg);
+        if let Ok(mut config) = crate::config::ClinConfig::load() {
+            config.list.show_hidden_files = self.list.show_hidden_files;
             if let Err(e) = config.save() {
                 self.set_temporary_status(&format!("Failed to save config: {e}"));
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -508,7 +508,10 @@ impl App {
         let all_folders = if let Some(ref cache) = self.list.folder_cache {
             cache
         } else {
-            let folders = self.storage.list_folders(self.list.show_hidden_files).unwrap_or_default();
+            let folders = self
+                .storage
+                .list_folders(self.list.show_hidden_files)
+                .unwrap_or_default();
             self.list.folder_cache = Some(folders);
             self.list
                 .folder_cache
@@ -3757,7 +3760,10 @@ template = """
                 let all_folders = if let Some(ref cache) = self.list.folder_cache {
                     cache.clone()
                 } else {
-                    let folders = self.storage.list_folders(self.list.show_hidden_files).unwrap_or_default();
+                    let folders = self
+                        .storage
+                        .list_folders(self.list.show_hidden_files)
+                        .unwrap_or_default();
                     self.list.folder_cache = Some(folders.clone());
                     folders
                 };

--- a/src/config.rs
+++ b/src/config.rs
@@ -642,6 +642,8 @@ pub struct ListConfig {
     pub default_sort_order: Option<crate::app::SortOrder>,
     #[serde(default)]
     pub pinned_on_top: bool,
+    #[serde(default)]
+    pub show_hidden_files: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -1421,6 +1423,9 @@ default_view = "grid"
 
 # Keep pinned notes at the top of the list.
 pinned_on_top = true
+
+# Show hidden files and folders (starting with ".") in the notes list.
+show_hidden_files = false
 
 # ── Editor ────────────────────────────────────────────────────────────────────
 

--- a/src/graf/graph.rs
+++ b/src/graf/graph.rs
@@ -30,7 +30,7 @@ pub fn build_graph(
     storage: &Storage,
     config: &ClinConfig,
 ) -> anyhow::Result<ForceGraph<GraphNodeData, ()>> {
-    let note_ids = storage.list_note_ids()?;
+    let note_ids = storage.list_note_ids(!config.list.show_hidden_files)?;
     let mut graph: ForceGraph<GraphNodeData, ()> = ForceGraph::default();
     let mut title_to_index: HashMap<String, NodeIndex> = HashMap::new();
 

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -80,6 +80,7 @@ pub struct ListView {
     pub list_density: crate::config::ListDensity,
     pub show_file_size: bool,
     pub show_date_in_list: bool,
+    pub show_hidden_files: bool,
 }
 
 impl Default for ListView {
@@ -108,6 +109,7 @@ impl Default for ListView {
             notes_layout: crate::config::NotesLayout::default(),
             list_density: crate::config::ListDensity::Compact,
             show_file_size: false,
+            show_hidden_files: false,
             show_date_in_list: true,
             grid_folder: String::new(),
             grid_columns: 4,

--- a/src/main.rs
+++ b/src/main.rs
@@ -344,22 +344,57 @@ fn run_storage(action: StorageCmd) -> Result<()> {
             let mut skipped_count = 0;
             let mut conflict_action: Option<migration::ConflictAction> = None;
 
-            let notes_src = from.join("notes");
-            let notes_dst = to.join("notes");
+            let source_is_vault = from.join(".clin").is_dir();
+            let target_is_vault = is_existing_vault(&to);
+
+            // Determine effective source dirs (vault mode: notes at root, .clin/templates/)
+            let notes_src = if source_is_vault {
+                from.clone()
+            } else {
+                from.join("notes")
+            };
+            let templates_src = if source_is_vault {
+                from.join(".clin").join("templates")
+            } else {
+                from.join("templates")
+            };
+
+            // Determine effective target dirs
+            let notes_dst = if target_is_vault {
+                to.clone()
+            } else {
+                to.join("notes")
+            };
+            let templates_dst = if target_is_vault {
+                to.join(".clin").join("templates")
+            } else {
+                to.join("templates")
+            };
+
+            // Migrate notes
             if notes_src.exists() && notes_src.is_dir() {
                 fs::create_dir_all(&notes_dst)?;
-                let (m, s, action) = migration::migrate_directory_with_conflict(
-                    &notes_src,
-                    &notes_dst,
-                    conflict_action,
-                )?;
+                let (m, s, action) = if source_is_vault {
+                    // Vault-mode source: only copy note files, skip hidden/clin dirs
+                    migration::migrate_note_files_with_conflict(
+                        &notes_src,
+                        &notes_dst,
+                        conflict_action,
+                    )?
+                } else {
+                    // Clin-native source: full directory copy
+                    migration::migrate_directory_with_conflict(
+                        &notes_src,
+                        &notes_dst,
+                        conflict_action,
+                    )?
+                };
                 migrated_count += m;
                 skipped_count += s;
                 conflict_action = action;
             }
 
-            let templates_src = from.join("templates");
-            let templates_dst = to.join("templates");
+            // Migrate templates
             if templates_src.exists() && templates_src.is_dir() {
                 fs::create_dir_all(&templates_dst)?;
                 let (m, s, _) = migration::migrate_directory_with_conflict(

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
+use std::path::PathBuf;
 
 #[derive(Clone, Copy)]
 pub enum ConflictAction {
@@ -105,6 +106,63 @@ pub fn migrate_directory_with_conflict(
             migrated += m;
             skipped += s;
             current_action = action;
+        }
+    }
+
+    Ok((migrated, skipped, current_action))
+}
+
+/// Copy note files from `src` to `dst`, preserving relative paths.
+/// Skips hidden directories and `notes/`, `templates/`, `.clin/` subdirectories.
+/// Only copies files with note extensions (.md, .txt, .clin, .draw, .canvas).
+pub fn migrate_note_files_with_conflict(
+    src: &Path,
+    dst: &Path,
+    current_action: Option<ConflictAction>,
+) -> Result<(usize, usize, Option<ConflictAction>)> {
+    let note_exts = ["md", "txt", "clin", "draw", "canvas"];
+    let mut migrated = 0;
+    let mut skipped = 0;
+    let mut current_action = current_action;
+    let mut dirs_to_visit = vec![PathBuf::new()];
+
+    while let Some(rel) = dirs_to_visit.pop() {
+        let abs = src.join(&rel);
+        let Ok(entries) = fs::read_dir(&abs) else { continue };
+        for entry in entries.flatten() {
+            let file_name = entry.file_name();
+            let abs_path = entry.path();
+            let rel_path = rel.join(&file_name);
+
+            if abs_path.is_dir() {
+                // Skip hidden dirs and clin internal dirs
+                if let Some(name) = file_name.to_str() {
+                    if name.starts_with('.') || name == "notes" || name == "templates" {
+                        continue;
+                    }
+                }
+                dirs_to_visit.push(rel_path);
+            } else if abs_path.is_file() {
+                if let Some(ext) = abs_path.extension().and_then(|e| e.to_str()) {
+                    if note_exts.contains(&ext) {
+                        let dst_path = dst.join(&rel_path);
+                        if let Some(parent) = dst_path.parent() {
+                            fs::create_dir_all(parent)
+                                .with_context(|| format!("failed to create {}", parent.display()))?;
+                        }
+                        let display_name = rel_path.to_string_lossy().to_string();
+                        let (m, s, action) = migrate_file_with_conflict(
+                            &abs_path,
+                            &dst_path,
+                            &display_name,
+                            current_action,
+                        )?;
+                        migrated += m;
+                        skipped += s;
+                        current_action = action;
+                    }
+                }
+            }
         }
     }
 

--- a/src/migration.rs
+++ b/src/migration.rs
@@ -128,7 +128,9 @@ pub fn migrate_note_files_with_conflict(
 
     while let Some(rel) = dirs_to_visit.pop() {
         let abs = src.join(&rel);
-        let Ok(entries) = fs::read_dir(&abs) else { continue };
+        let Ok(entries) = fs::read_dir(&abs) else {
+            continue;
+        };
         for entry in entries.flatten() {
             let file_name = entry.file_name();
             let abs_path = entry.path();
@@ -136,32 +138,31 @@ pub fn migrate_note_files_with_conflict(
 
             if abs_path.is_dir() {
                 // Skip hidden dirs and clin internal dirs
-                if let Some(name) = file_name.to_str() {
-                    if name.starts_with('.') || name == "notes" || name == "templates" {
-                        continue;
-                    }
+                if let Some(name) = file_name.to_str()
+                    && (name.starts_with('.') || name == "notes" || name == "templates")
+                {
+                    continue;
                 }
                 dirs_to_visit.push(rel_path);
-            } else if abs_path.is_file() {
-                if let Some(ext) = abs_path.extension().and_then(|e| e.to_str()) {
-                    if note_exts.contains(&ext) {
-                        let dst_path = dst.join(&rel_path);
-                        if let Some(parent) = dst_path.parent() {
-                            fs::create_dir_all(parent)
-                                .with_context(|| format!("failed to create {}", parent.display()))?;
-                        }
-                        let display_name = rel_path.to_string_lossy().to_string();
-                        let (m, s, action) = migrate_file_with_conflict(
-                            &abs_path,
-                            &dst_path,
-                            &display_name,
-                            current_action,
-                        )?;
-                        migrated += m;
-                        skipped += s;
-                        current_action = action;
-                    }
+            } else if abs_path.is_file()
+                && let Some(ext) = abs_path.extension().and_then(|e| e.to_str())
+                && note_exts.contains(&ext)
+            {
+                let dst_path = dst.join(&rel_path);
+                if let Some(parent) = dst_path.parent() {
+                    fs::create_dir_all(parent)
+                        .with_context(|| format!("failed to create {}", parent.display()))?;
                 }
+                let display_name = rel_path.to_string_lossy().to_string();
+                let (m, s, action) = migrate_file_with_conflict(
+                    &abs_path,
+                    &dst_path,
+                    &display_name,
+                    current_action,
+                )?;
+                migrated += m;
+                skipped += s;
+                current_action = action;
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -131,7 +131,9 @@ fn has_note_files_outside_clin_dirs(dir: &Path) -> bool {
     while let Some(path) = dirs.pop() {
         if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
             // Skip clin internal dirs, hidden dirs, but not the root vault dir itself
-            if path.as_path() != dir && (name == "notes" || name == "templates" || name.starts_with('.')) {
+            if path.as_path() != dir
+                && (name == "notes" || name == "templates" || name.starts_with('.'))
+            {
                 continue;
             }
         }
@@ -140,10 +142,10 @@ fn has_note_files_outside_clin_dirs(dir: &Path) -> bool {
                 let p = entry.path();
                 if p.is_dir() {
                     dirs.push(p);
-                } else if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
-                    if note_exts.contains(&ext) {
-                        return true;
-                    }
+                } else if let Some(ext) = p.extension().and_then(|e| e.to_str())
+                    && note_exts.contains(&ext)
+                {
+                    return true;
                 }
             }
         }
@@ -160,10 +162,10 @@ fn has_note_files_recursive(dir: &Path) -> bool {
                 let p = entry.path();
                 if p.is_dir() {
                     dirs.push(p);
-                } else if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
-                    if note_exts.contains(&ext) {
-                        return true;
-                    }
+                } else if let Some(ext) = p.extension().and_then(|e| e.to_str())
+                    && note_exts.contains(&ext)
+                {
+                    return true;
                 }
             }
         }
@@ -196,7 +198,7 @@ impl Storage {
         };
 
         if vault_mode {
-            fs::create_dir_all(&data_dir.join(".clin").join("templates"))
+            fs::create_dir_all(data_dir.join(".clin").join("templates"))
                 .context("failed to create .clin/templates directory")?;
         } else {
             fs::create_dir_all(&notes_dir).context("failed to create notes directory")?;
@@ -492,7 +494,10 @@ impl Storage {
                 let path = entry.path();
 
                 if path.is_dir()
-                    && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| include_hidden || !n.starts_with('.'))
+                    && path
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .is_some_and(|n| include_hidden || !n.starts_with('.'))
                 {
                     dirs_to_visit.push(path);
                 } else if let Some(ext) = path.extension().and_then(|e| e.to_str())
@@ -1007,7 +1012,10 @@ impl Storage {
                 for entry in entries.flatten() {
                     let path = entry.path();
                     if path.is_dir()
-                        && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| include_hidden || !n.starts_with('.'))
+                        && path
+                            .file_name()
+                            .and_then(|s| s.to_str())
+                            .is_some_and(|n| include_hidden || !n.starts_with('.'))
                     {
                         dirs_to_visit.push(path.clone());
                         if let Ok(rel_path) = path.strip_prefix(&self.notes_dir)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -482,7 +482,7 @@ impl Storage {
         Some(self.notes_dir.join(normalized))
     }
 
-    pub fn list_note_ids(&self) -> Result<Vec<String>> {
+    pub fn list_note_ids(&self, include_hidden: bool) -> Result<Vec<String>> {
         let mut ids = Vec::new();
         let mut dirs_to_visit = vec![self.notes_dir.clone()];
 
@@ -492,7 +492,7 @@ impl Storage {
                 let path = entry.path();
 
                 if path.is_dir()
-                    && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| !n.starts_with('.'))
+                    && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| include_hidden || !n.starts_with('.'))
                 {
                     dirs_to_visit.push(path);
                 } else if let Some(ext) = path.extension().and_then(|e| e.to_str())
@@ -998,7 +998,7 @@ impl Storage {
         Ok(target_id)
     }
 
-    pub fn list_folders(&self) -> Result<Vec<String>> {
+    pub fn list_folders(&self, include_hidden: bool) -> Result<Vec<String>> {
         let mut folders = Vec::new();
         let mut dirs_to_visit = vec![self.notes_dir.clone()];
 
@@ -1007,7 +1007,7 @@ impl Storage {
                 for entry in entries.flatten() {
                     let path = entry.path();
                     if path.is_dir()
-                        && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| !n.starts_with('.'))
+                        && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| include_hidden || !n.starts_with('.'))
                     {
                         dirs_to_visit.push(path.clone());
                         if let Ok(rel_path) = path.strip_prefix(&self.notes_dir)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,7 +10,7 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,6 +103,73 @@ fn split_frontmatter_payload(bytes: &[u8]) -> (Option<frontmatter::Frontmatter>,
     (None, bytes)
 }
 
+/// Check if `dir` is an existing vault (has notes outside clin subdirectories).
+/// If `.clin/` sentinel exists, it's definitely a vault.
+/// Otherwise, scan for note files outside `notes/` and `templates/`.
+pub(crate) fn is_existing_vault(dir: &Path) -> bool {
+    // Sentinel directory: if .clin/ exists, this is definitely a vault
+    if dir.join(".clin").is_dir() {
+        return true;
+    }
+
+    // If notes/ exists with content, this is clin-native mode — don't treat as vault
+    let notes_dir = dir.join("notes");
+    if notes_dir.exists() {
+        let has_notes = has_note_files_recursive(&notes_dir);
+        if has_notes {
+            return false; // clin-native layout, keep backward compat
+        }
+    }
+
+    // Scan for note files at root or in subdirectories (excluding notes/, templates/)
+    has_note_files_outside_clin_dirs(dir)
+}
+
+fn has_note_files_outside_clin_dirs(dir: &Path) -> bool {
+    let note_exts = ["md", "txt", "clin", "draw", "canvas"];
+    let mut dirs = vec![dir.to_path_buf()];
+    while let Some(path) = dirs.pop() {
+        if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+            // Skip clin internal dirs, hidden dirs, but not the root vault dir itself
+            if path.as_path() != dir && (name == "notes" || name == "templates" || name.starts_with('.')) {
+                continue;
+            }
+        }
+        if let Ok(entries) = fs::read_dir(&path) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    dirs.push(p);
+                } else if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
+                    if note_exts.contains(&ext) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+fn has_note_files_recursive(dir: &Path) -> bool {
+    let note_exts = ["md", "txt", "clin", "draw", "canvas"];
+    let mut dirs = vec![dir.to_path_buf()];
+    while let Some(path) = dirs.pop() {
+        if let Ok(entries) = fs::read_dir(&path) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    dirs.push(p);
+                } else if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
+                    if note_exts.contains(&ext) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
 impl Storage {
     pub fn init() -> Result<Self> {
         let bootstrap = ClinConfig::load().context("failed to load config")?;
@@ -114,10 +181,27 @@ impl Storage {
             .context("could not determine config directory")?;
         let config_dir = proj_dirs.config_dir().to_path_buf();
 
-        let notes_dir = data_dir.join("notes");
-        let templates_dir = data_dir.join("templates");
-        fs::create_dir_all(&notes_dir).context("failed to create notes directory")?;
-        fs::create_dir_all(&templates_dir).context("failed to create templates directory")?;
+        let vault_mode = is_existing_vault(&data_dir);
+
+        let notes_dir = if vault_mode {
+            data_dir.clone()
+        } else {
+            data_dir.join("notes")
+        };
+
+        let templates_dir = if vault_mode {
+            data_dir.join(".clin").join("templates")
+        } else {
+            data_dir.join("templates")
+        };
+
+        if vault_mode {
+            fs::create_dir_all(&data_dir.join(".clin").join("templates"))
+                .context("failed to create .clin/templates directory")?;
+        } else {
+            fs::create_dir_all(&notes_dir).context("failed to create notes directory")?;
+            fs::create_dir_all(&templates_dir).context("failed to create templates directory")?;
+        }
 
         let old_key_path = data_dir.join("key.bin");
         let key_path = config_dir.join("key.bin");
@@ -170,7 +254,9 @@ impl Storage {
             templates_dir,
             key,
         };
-        storage.migrate_extensions();
+        if !vault_mode {
+            storage.migrate_extensions();
+        }
         Ok(storage)
     }
 
@@ -405,7 +491,9 @@ impl Storage {
                 let entry = entry.context("failed to read entry")?;
                 let path = entry.path();
 
-                if path.is_dir() {
+                if path.is_dir()
+                    && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| !n.starts_with('.'))
+                {
                     dirs_to_visit.push(path);
                 } else if let Some(ext) = path.extension().and_then(|e| e.to_str())
                     && (ext == "clin"
@@ -918,7 +1006,9 @@ impl Storage {
             if let Ok(entries) = fs::read_dir(&dir) {
                 for entry in entries.flatten() {
                     let path = entry.path();
-                    if path.is_dir() {
+                    if path.is_dir()
+                        && path.file_name().and_then(|s| s.to_str()).is_some_and(|n| !n.starts_with('.'))
+                    {
                         dirs_to_visit.push(path.clone());
                         if let Ok(rel_path) = path.strip_prefix(&self.notes_dir)
                             && let Some(rel_str) = rel_path.to_str()


### PR DESCRIPTION
## FIXED

  - `migrate_note_files_with_conflict` now detects `.clin` vault markers on
    source and target paths — previously hardcoded to `notes/` directories,
    breaking vault-to-vault migration
  - Issue #50 

## CHANGED

  - Added `show_hidden_files` config option (default `false`) in `[list]`
    section — `list_note_ids()` and `list_folders()` accept `include_hidden`
    param to gate dotfile filtering; graph view respects the toggle
  - New `ToggleShowHiddenFilesAction` in command palette with dynamic
    `[On]/[Off]` label — toggles visibility immediately and persists to config
    
## NOTE that these changes are backwards compatible, you DO NOT need to migrate your storage