### PR TITLE
fix: replace deprecated xorg.libX11/xorg.libxcb with libx11/libxcb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /dev_scripts/
 /info/
 /graphify-out/
+
+# nix build result
+/result

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,8 @@
             openssl
             zlib
             libgit2
-            xorg.libX11
-            xorg.libxcb
+            libx11
+            libxcb
           ];
 
           meta = with pkgs.lib; {
@@ -52,8 +52,8 @@
             openssl
             zlib
             libgit2
-            xorg.libX11
-            xorg.libxcb
+            libx11
+            libxcb
           ];
         };
       }


### PR DESCRIPTION
## What

Update flake.nix to use the current attribute names for libx11 and libxcb.

## Why

xorg.libX11 and xorg.libxcb have been renamed upstream to libx11 and libxcb respectively. 