### PR TITLE
fix(list): correct jump-to-top dispatch and add jump-to-bottom defaults

### DIFF
--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -259,8 +259,8 @@ Key combos are strings like `"a"`, `"Enter"`, `"Ctrl+q"`, `"Ctrl+Shift+z"`, `"Al
 | `toggle_pin` | `p` | Pin/unpin note |
 | `cycle_sort` | `s` | Cycle sort options |
 | `search` | `Ctrl+f` | Quick search by title |
-| `jump_to_top` | `Shift+G` | Jump to top of list |
-| `jump_to_bottom` | — | Jump to bottom of list |
+| `jump_to_top` | `Shift+U` | Jump to top of list |
+| `jump_to_bottom` | `Shift+D` | Jump to bottom of list |
 | `page_up` | `Ctrl+u` | Half page up |
 | `page_down` | `Ctrl+d` | Half page down |
 | `open_trash` | `Shift+T` | Open trash view |

--- a/src/events.rs
+++ b/src/events.rs
@@ -993,6 +993,10 @@ pub fn handle_list_keys(app: &mut App, key: KeyEvent) -> bool {
         return false;
     }
     if app.keybinds.matches_list(ListAction::JumpToTop, &key) {
+        app.jump_to_top();
+        return false;
+    }
+    if app.keybinds.matches_list(ListAction::JumpToBottom, &key) {
         app.jump_to_bottom();
         return false;
     }

--- a/src/keybinds.rs
+++ b/src/keybinds.rs
@@ -544,7 +544,11 @@ impl Default for Keybinds {
         );
         list.insert(
             ListAction::JumpToTop,
-            vec![KeyCombo::shift(KeyCode::Char('G'))],
+            vec![KeyCombo::shift(KeyCode::Char('U'))],
+        );
+        list.insert(
+            ListAction::JumpToBottom,
+            vec![KeyCombo::shift(KeyCode::Char('D'))],
         );
         list.insert(ListAction::PageUp, vec![KeyCombo::ctrl(KeyCode::Char('u'))]);
         list.insert(


### PR DESCRIPTION
- `JumpToTop` was calling `jump_to_bottom()` instead of `jump_to_top()`
- `JumpToBottom` had no dispatch handler, so custom keybinds were ignored
- Set `Shift+U` as default for jump-to-top, `Shift+D` for jump-to-bottom