### PR TITLE
Removed arbitrary style enforcer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Once inside the TUI: navigate with `j`/`k`, open notes with `Enter`, open the co
 
 | View | Purpose | Key Actions |
 |---|---|---|
-| **List / Notes** | Browse, search, filter, manage notes | Grid/Tree layout, format chooser, folders, tags, sort, pin, glow preview, search, trash, copy/move/delete |
+| **List / Notes** | Browse, search, filter, manage notes | Grid/Tree layout, format chooser, folders, tags, sort, pin, glow preview(using the configured theme in glow), search, trash, copy/move/delete |
 | **Editor** | Write and edit notes | Title + body, undo/redo, mouse support, line numbers, markdown preview pane, external editor |
 | **Graph** | Visualize note connections | Force-directed layout, [[wikilinks]] edges, physics, preview pane, minimap, legend, search, grid, configurable colors |
 | **Backup** | Git-based vault versioning | Status (staged/unstaged), commit history, diff preview, auto-push, remote sync |

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -283,8 +283,6 @@ fn render_in_thread(
     let mut cmd = CommandBuilder::new("glow");
     cmd.arg("-w");
     cmd.arg(cols.to_string());
-    cmd.arg("-s");
-    cmd.arg("dark");
     cmd.arg(&temp_path);
     cmd.env("TERM", "dumb");
     cmd.env("PAGER", "cat");


### PR DESCRIPTION
## What

Removed the '-s dark' flag on glow, found in markdown.go

## Why

Glow's config deals with glow's style, and clin enforcing dark disallows custom and/or light mode themes.

## How
It is, I feel, obvious; remove two lines that basically say "force dark style"

## Checklist

- [X] `cargo fmt` passes;
cargo fmt produces no output
- [    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.85s ] `cargo clippy -- -D warnings` passes
- [ X ] `cargo test` passes
```
running 48 tests
test actions::import::tests::test_file_stem_title ... ok
[rest of the tests...]
test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```
- [X] Documentation updated
I didn't add much, but pointed out that custom theming with glow is possible.