### PR TITLE
support unicode in note and template filenames

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1104,7 +1104,7 @@ impl Storage {
 
         let mut out = String::new();
         for ch in source.chars() {
-            let valid = ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '-' | '_' | '.');
+            let valid = ch.is_alphanumeric() || matches!(ch, ' ' | '-' | '_' | '.');
             out.push(if valid { ch } else { '_' });
         }
 

--- a/src/templates/store.rs
+++ b/src/templates/store.rs
@@ -1,7 +1,7 @@
 pub fn sanitize_filename(name: &str) -> String {
     let mut result = String::new();
     for c in name.chars() {
-        if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+        if c.is_alphanumeric() || c == '-' || c == '_' {
             result.push(c.to_ascii_lowercase());
         } else if c == ' ' {
             result.push('_');


### PR DESCRIPTION
## What

replace is_ascii_alphanumeric() with is_alphanumeric() in filename sanitization

## Why

fixes cyrillic and other unicode characters being replaced with _ in filenames

## How

Key implementation details (if non-obvious).

## Checklist

- [x] `cargo fmt` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Documentation updated (if applicable)

before
<img width="862" height="605" alt="Screenshot from 2026-08-03 14-52-25" src="https://github.com/user-attachments/assets/c64dafdb-d1b1-4a8d-a0d4-11741be62b00" />
after
<img width="1049" height="711" alt="Screenshot from 2026-08-03 14-54-53" src="https://github.com/user-attachments/assets/6733ca71-94f2-4f76-9b95-59744cba04df" />
