### PR TITLE
feat(config): add scrollbar pan mode for notes list

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -275,6 +275,7 @@ pub static ACTIONS: std::sync::LazyLock<Vec<Box<dyn Action>>> = std::sync::LazyL
         Box::new(settings::ToggleGhostSyntaxAction),
         Box::new(settings::ToggleExtendedMarkdownAction),
         Box::new(settings::ToggleScrollbarsAction),
+        Box::new(settings::ToggleScrollbarPanModeAction),
         Box::new(settings::ToggleSyntaxHighlightingAction),
         Box::new(settings::ToggleCodeLineNumbersAction),
         Box::new(settings::ToggleShowFileSizeAction),

--- a/src/actions/settings.rs
+++ b/src/actions/settings.rs
@@ -373,6 +373,23 @@ toggle_action!(
 );
 
 toggle_action!(
+    ToggleScrollbarPanModeAction,
+    "settings.scrollbar_pan_mode",
+    "Toggle Scrollbar Pan Mode",
+    "Scrollbar pans the viewport instead of moving selection; any key snaps back",
+    ActionCategory::Settings,
+    "\u{f878}",
+    "\u{1f4d7}",
+    toggle_scrollbar_pan_mode,
+    app,
+    if app.config.ui.scrollbar_pan_mode {
+        "On"
+    } else {
+        "Off"
+    }
+);
+
+toggle_action!(
     ToggleSyntaxHighlightingAction,
     "settings.syntax_highlighting",
     "Toggle Syntax Highlighting",

--- a/src/app/loading.rs
+++ b/src/app/loading.rs
@@ -12,6 +12,7 @@ struct SmartFolderData {
 }
 impl App {
     pub fn refresh_visual_list(&mut self) {
+        self.list.list_viewport_offset = None;
         let mut visual = Vec::new();
         // Subnotes view cache — computed first (before any &self.notes borrow) to avoid conflict.
         let subnotes_cache = if self.subnotes_view_cache_sig

--- a/src/app/settings_ops.rs
+++ b/src/app/settings_ops.rs
@@ -715,6 +715,22 @@ impl App {
         }
     }
 
+    pub fn toggle_scrollbar_pan_mode(&mut self) {
+        self.config.ui.scrollbar_pan_mode = !self.config.ui.scrollbar_pan_mode;
+        self.list.list_viewport_offset = None;
+        self.set_temporary_status_static(if self.config.ui.scrollbar_pan_mode {
+            "Scrollbar pan mode on"
+        } else {
+            "Scrollbar pan mode off"
+        });
+        if let Ok(mut config) = crate::config::ClinConfig::load().0 {
+            config.ui.scrollbar_pan_mode = self.config.ui.scrollbar_pan_mode;
+            if let Err(e) = config.save() {
+                self.set_temporary_status(&format!("Failed to save config: {e}"));
+            }
+        }
+    }
+
     pub fn toggle_syntax_highlighting(&mut self) {
         self.config.core.syntax_highlighting = !self.config.core.syntax_highlighting;
         self.set_temporary_status_static(if self.config.core.syntax_highlighting {

--- a/src/config/merge.rs
+++ b/src/config/merge.rs
@@ -233,6 +233,11 @@ show_status_bar = true
 # Show mouse-draggable scrollbars on scrollable regions.
 scrollbars = true
 
+# When true, dragging the notes-list scrollbar pans the viewport instead of
+# moving the selection; pressing any key snaps the viewport back to the
+# selection.
+# scrollbar_pan_mode = false
+
 # Icon mode ("nerd", "unicode", "none"). Controls icon rendering throughout the app.
 icon_mode = "nerd"
 

--- a/src/config/structs.rs
+++ b/src/config/structs.rs
@@ -266,6 +266,11 @@ pub struct UiConfig {
     /// Show mouse-draggable scrollbars on scrollable regions.
     #[serde(default = "default_true")]
     pub scrollbars: bool,
+    /// When true, dragging/clicking the notes-list scrollbar pans the viewport
+    /// without moving the selection; any key snaps the viewport back to the
+    /// selection (first press is consumed).
+    #[serde(default)]
+    pub scrollbar_pan_mode: bool,
     #[serde(default)]
     pub hint_bar_style: HintBarStyle,
 }
@@ -289,6 +294,7 @@ impl Default for UiConfig {
             tab_icons_only: false,
             icon_mode: IconMode::default(),
             scrollbars: default_true(),
+            scrollbar_pan_mode: false,
             hint_bar_style: HintBarStyle::default(),
         }
     }

--- a/src/events/list.rs
+++ b/src/events/list.rs
@@ -8,6 +8,11 @@ use crate::list_view::ListMode;
 use super::contains_cell;
 
 pub fn handle_list_keys(app: &mut App, key: KeyEvent) -> bool {
+    // Snap-only: first key after scrollbar pan snaps viewport back to
+    // selection and is consumed.
+    if app.list.list_viewport_offset.take().is_some() {
+        return true;
+    }
     if app.layout_edit {
         match key.code {
             KeyCode::Esc => {
@@ -563,19 +568,42 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
         && let Some(meta) = app.list.last_scroll
     {
         let content_len = meta.content_len;
-        let frac = app.list.visual_index as f32 / content_len.max(1).saturating_sub(1) as f32;
-        if let Some(new_frac) = crate::ui::scrollbar::handle_scrollbar_mouse(
-            &mouse_event,
-            meta,
-            frac,
-            &mut app.list.scroll_drag,
-        ) {
-            let max_pos = content_len.saturating_sub(1);
-            let pos = (new_frac * max_pos as f32).round() as usize;
-            app.list.list_state.select(Some(pos.min(max_pos)));
-            app.list.visual_index = pos.min(max_pos);
-            app.request_preview_update_immediate();
-            return;
+        let viewport_len = meta.viewport_len;
+        let max_off = content_len.saturating_sub(viewport_len);
+
+        if app.config.ui.scrollbar_pan_mode {
+            // Pan viewport only; leave visual_index + list_state untouched.
+            let cur_off = app
+                .list
+                .list_viewport_offset
+                .unwrap_or(app.list.list_state.offset())
+                .min(max_off);
+            let frac = cur_off as f32 / max_off.max(1) as f32;
+            if let Some(new_frac) = crate::ui::scrollbar::handle_scrollbar_mouse(
+                &mouse_event,
+                meta,
+                frac,
+                &mut app.list.scroll_drag,
+            ) {
+                let off = ((new_frac * max_off as f32).round() as usize).min(max_off);
+                app.list.list_viewport_offset = Some(off);
+                return;
+            }
+        } else {
+            let frac = app.list.visual_index as f32 / content_len.max(1).saturating_sub(1) as f32;
+            if let Some(new_frac) = crate::ui::scrollbar::handle_scrollbar_mouse(
+                &mouse_event,
+                meta,
+                frac,
+                &mut app.list.scroll_drag,
+            ) {
+                let max_pos = content_len.saturating_sub(1);
+                let pos = (new_frac * max_pos as f32).round() as usize;
+                app.list.list_state.select(Some(pos.min(max_pos)));
+                app.list.visual_index = pos.min(max_pos);
+                app.request_preview_update_immediate();
+                return;
+            }
         }
     }
 
@@ -770,6 +798,7 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
     }
 
     if mouse_event.kind == MouseEventKind::ScrollUp {
+        app.list.list_viewport_offset = None;
         let current = app.list.list_state.selected().unwrap_or(0);
         app.list.list_state.select(Some(current.saturating_sub(1)));
 
@@ -778,6 +807,7 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
     }
 
     if mouse_event.kind == MouseEventKind::ScrollDown {
+        app.list.list_viewport_offset = None;
         handle_list_keys(app, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
         return;
     }
@@ -991,6 +1021,7 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
         ) else {
             return;
         };
+        app.list.list_viewport_offset = None;
         app.list.visual_index = clicked_visual_index;
         app.request_preview_update_immediate();
         if let Some(crate::app::VisualItem::Note { summary_idx, .. }) =
@@ -1019,6 +1050,7 @@ pub fn handle_list_mouse(app: &mut App, mouse_event: MouseEvent, terminal_area: 
         ) else {
             return;
         };
+        app.list.list_viewport_offset = None;
         if app.list.notes_layout == crate::config::NotesLayout::Tree
             && let Some(crate::list_view::VisualItem::Note { .. }) =
                 app.list.visual_list.get(clicked_visual_index)

--- a/src/list_view.rs
+++ b/src/list_view.rs
@@ -168,6 +168,9 @@ pub struct ListView {
     pub drag_hover: Option<usize>,
     pub last_scroll: Option<crate::ui::scrollbar::ScrollbarMeta>,
     pub scroll_drag: Option<crate::ui::scrollbar::ScrollDrag>,
+    /// When set, the list viewport is panned independently of `visual_index`
+    /// (scrollbar pan mode). Cleared on any keypress / row click / wheel.
+    pub list_viewport_offset: Option<usize>,
 }
 
 impl Default for ListView {
@@ -224,6 +227,7 @@ impl Default for ListView {
             preview_drag_last_pos: None,
             last_scroll: None,
             scroll_drag: None,
+            list_viewport_offset: None,
         }
     }
 }

--- a/src/ui/list_view.rs
+++ b/src/ui/list_view.rs
@@ -1492,19 +1492,28 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
             let total_len = app.list.visual_list.len();
             let viewport_len = list_area.height.saturating_sub(2) as usize;
 
-            let mut offset = app.list.list_state.offset();
-            if offset > total_len.saturating_sub(viewport_len) {
-                offset = total_len.saturating_sub(viewport_len);
-            }
-            if app.list.visual_index < offset {
-                offset = app.list.visual_index;
-            } else if app.list.visual_index >= offset + viewport_len {
-                offset = app
-                    .list
-                    .visual_index
-                    .saturating_add(1)
-                    .saturating_sub(viewport_len);
-            }
+            let max_off = total_len.saturating_sub(viewport_len);
+
+            let offset = if app.config.ui.scrollbar_pan_mode
+                && let Some(off) = app.list.list_viewport_offset
+            {
+                off.min(max_off)
+            } else {
+                let mut o = app.list.list_state.offset();
+                if o > max_off {
+                    o = max_off;
+                }
+                if app.list.visual_index < o {
+                    o = app.list.visual_index;
+                } else if app.list.visual_index >= o + viewport_len {
+                    o = app
+                        .list
+                        .visual_index
+                        .saturating_add(1)
+                        .saturating_sub(viewport_len);
+                }
+                o
+            };
             *app.list.list_state.offset_mut() = offset;
 
             let end = (offset + viewport_len).min(total_len);
@@ -1563,9 +1572,12 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
                     items.push(item);
                 }
             }
-            let relative_selected = app.list.visual_index.saturating_sub(offset);
             let mut rel_state = ListState::default();
-            rel_state.select(Some(relative_selected));
+            if (offset..end).contains(&app.list.visual_index) {
+                rel_state.select(Some(app.list.visual_index - offset));
+            } else {
+                rel_state.select(None);
+            }
 
             let list = List::new(items)
                 .block(
@@ -1589,13 +1601,18 @@ pub fn draw_list_view(frame: &mut Frame, app: &mut App) {
             };
             app.list.last_scroll = Some(meta);
             if app.config.ui.scrollbars {
+                let (pos, max_pos) = if app.config.ui.scrollbar_pan_mode {
+                    (offset, max_off)
+                } else {
+                    (app.list.visual_index, total_len.saturating_sub(1))
+                };
                 crate::ui::scrollbar::draw_scrollbar(
                     frame,
                     list_area,
                     content_len,
                     viewport_len,
-                    app.list.visual_index,
-                    content_len.saturating_sub(1),
+                    pos,
+                    max_pos,
                     &app.app_theme,
                 );
             }


### PR DESCRIPTION
Added `scrollbar_pan_mode` which makes the scrollbar in the notes view move/not move the selection.