### PR TITLE
Feat/pinstar

### DIFF
--- a/src/app/views.rs
+++ b/src/app/views.rs
@@ -191,6 +191,21 @@ impl App {
                     crate::image_render::cache::ImageCache::new(self.config.image.cache_size);
                 state.image_picker = self.image_picker.clone();
                 state.image_decode_tx = self.image_decode_tx.clone();
+                // Load per-vault orthogonal preference
+                if let Ok(vault_id) =
+                    crate::local_state::vault_identity_path(&self.storage.data_dir)
+                {
+                    let vault_key = vault_id.to_string_lossy().into_owned();
+                    if let Ok(paths) = crate::paths::AppPaths::discover(
+                        crate::config::ClinConfig::config_path().unwrap_or_default(),
+                    ) {
+                        if let Ok(st) = crate::local_state::LocalState::load(&paths.state_path()) {
+                            if let Some(vs) = st.vaults.get(&vault_key) {
+                                state.orthogonal_connections = vs.canvas_orthogonal;
+                            }
+                        }
+                    }
+                }
                 self.canvas_state = Some(state);
                 self.set_default_status();
             } else {

--- a/src/app/views.rs
+++ b/src/app/views.rs
@@ -198,8 +198,7 @@ impl App {
                     let vault_key = vault_id.to_string_lossy().into_owned();
                     if let Ok(paths) = crate::paths::AppPaths::discover(
                         crate::config::ClinConfig::config_path().unwrap_or_default(),
-                    )
-                        && let Ok(st) = crate::local_state::LocalState::load(&paths.state_path())
+                    ) && let Ok(st) = crate::local_state::LocalState::load(&paths.state_path())
                         && let Some(vs) = st.vaults.get(&vault_key)
                     {
                         state.orthogonal_connections = vs.canvas_orthogonal;

--- a/src/app/views.rs
+++ b/src/app/views.rs
@@ -198,12 +198,11 @@ impl App {
                     let vault_key = vault_id.to_string_lossy().into_owned();
                     if let Ok(paths) = crate::paths::AppPaths::discover(
                         crate::config::ClinConfig::config_path().unwrap_or_default(),
-                    ) {
-                        if let Ok(st) = crate::local_state::LocalState::load(&paths.state_path()) {
-                            if let Some(vs) = st.vaults.get(&vault_key) {
-                                state.orthogonal_connections = vs.canvas_orthogonal;
-                            }
-                        }
+                    )
+                        && let Ok(st) = crate::local_state::LocalState::load(&paths.state_path())
+                        && let Some(vs) = st.vaults.get(&vault_key)
+                    {
+                        state.orthogonal_connections = vs.canvas_orthogonal;
                     }
                 }
                 self.canvas_state = Some(state);

--- a/src/keybinds/defaults.rs
+++ b/src/keybinds/defaults.rs
@@ -672,6 +672,18 @@ impl Default for Keybinds {
             vec![KeyCombo::simple(KeyCode::Char('b'))],
         );
         canvas.insert(
+            CanvasAction::AddTextNode,
+            vec![KeyCombo::simple(KeyCode::Char('t'))],
+        );
+        canvas.insert(
+            CanvasAction::AddGroup,
+            vec![KeyCombo::simple(KeyCode::Char('g'))],
+        );
+        canvas.insert(
+            CanvasAction::AddImageNode,
+            vec![KeyCombo::simple(KeyCode::Char('m'))],
+        );
+        canvas.insert(
             CanvasAction::ToggleGrid,
             vec![KeyCombo::shift(KeyCode::Char('G'))],
         );

--- a/src/keybinds/defaults.rs
+++ b/src/keybinds/defaults.rs
@@ -567,6 +567,14 @@ impl Default for Keybinds {
                 KeyCombo::simple(KeyCode::Char('q')),
             ],
         );
+        canvas.insert(CanvasAction::Undo, vec![KeyCombo::ctrl(KeyCode::Char('z'))]);
+        canvas.insert(
+            CanvasAction::Redo,
+            vec![
+                KeyCombo::ctrl(KeyCode::Char('y')),
+                KeyCombo::ctrl_shift(KeyCode::Char('z')),
+            ],
+        );
         canvas.insert(CanvasAction::Save, vec![KeyCombo::ctrl(KeyCode::Char('s'))]);
         canvas.insert(
             CanvasAction::ZoomFineIn,

--- a/src/keybinds/defaults.rs
+++ b/src/keybinds/defaults.rs
@@ -637,12 +637,39 @@ impl Default for Keybinds {
             vec![
                 KeyCombo::simple(KeyCode::Char('i')),
                 KeyCombo::simple(KeyCode::Enter),
-                KeyCombo::simple(KeyCode::Char('o')),
             ],
         );
         canvas.insert(
             CanvasAction::OpenContextMenu,
             vec![KeyCombo::simple(KeyCode::Char('a'))],
+        );
+        canvas.insert(
+            CanvasAction::CreateConnection,
+            vec![KeyCombo::simple(KeyCode::Char('c'))],
+        );
+        canvas.insert(
+            CanvasAction::DeleteConnection,
+            vec![KeyCombo::simple(KeyCode::Char('d'))],
+        );
+        canvas.insert(
+            CanvasAction::RenameNode,
+            vec![KeyCombo::simple(KeyCode::Char('r'))],
+        );
+        canvas.insert(
+            CanvasAction::ResizeMode,
+            vec![KeyCombo::simple(KeyCode::Char('s'))],
+        );
+        canvas.insert(
+            CanvasAction::SetColor,
+            vec![KeyCombo::simple(KeyCode::Char('o'))],
+        );
+        canvas.insert(
+            CanvasAction::DeleteNode,
+            vec![KeyCombo::simple(KeyCode::Char('x'))],
+        );
+        canvas.insert(
+            CanvasAction::DeleteAllConnections,
+            vec![KeyCombo::simple(KeyCode::Char('b'))],
         );
         canvas.insert(
             CanvasAction::ToggleGrid,

--- a/src/keybinds/defaults.rs
+++ b/src/keybinds/defaults.rs
@@ -718,19 +718,10 @@ impl Default for Keybinds {
             CanvasAction::MenuClose,
             vec![KeyCombo::simple(KeyCode::Esc)],
         );
-        canvas.insert(
-            CanvasAction::MenuUp,
-            vec![
-                KeyCombo::simple(KeyCode::Up),
-                KeyCombo::simple(KeyCode::Char('k')),
-            ],
-        );
+        canvas.insert(CanvasAction::MenuUp, vec![KeyCombo::simple(KeyCode::Up)]);
         canvas.insert(
             CanvasAction::MenuDown,
-            vec![
-                KeyCombo::simple(KeyCode::Down),
-                KeyCombo::simple(KeyCode::Char('j')),
-            ],
+            vec![KeyCombo::simple(KeyCode::Down)],
         );
         canvas.insert(
             CanvasAction::MenuSelect,

--- a/src/keybinds/defaults.rs
+++ b/src/keybinds/defaults.rs
@@ -649,6 +649,10 @@ impl Default for Keybinds {
             vec![KeyCombo::shift(KeyCode::Char('G'))],
         );
         canvas.insert(
+            CanvasAction::ToggleOrthogonal,
+            vec![KeyCombo::ctrl(KeyCode::Char('o'))],
+        );
+        canvas.insert(
             CanvasAction::ToggleEditorPane,
             vec![KeyCombo::ctrl(KeyCode::Char('e'))],
         );

--- a/src/keybinds/help_meta.rs
+++ b/src/keybinds/help_meta.rs
@@ -499,6 +499,14 @@ pub fn draw_action_meta(a: DrawAction) -> HelpMeta {
 
 pub fn canvas_action_meta(a: CanvasAction) -> HelpMeta {
     match a {
+        CanvasAction::Undo => HelpMeta {
+            group: "Editing",
+            description: "Undo last canvas edit",
+        },
+        CanvasAction::Redo => HelpMeta {
+            group: "Editing",
+            description: "Redo canvas edit",
+        },
         CanvasAction::MoveUp => HelpMeta {
             group: "Navigation",
             description: "Move up",

--- a/src/keybinds/help_meta.rs
+++ b/src/keybinds/help_meta.rs
@@ -24,6 +24,7 @@ pub fn canvas_group_order() -> &'static [&'static str] {
     &[
         "Navigation",
         "Editing",
+        "Connections",
         "Display",
         "Interface",
         "Menus & Popups",
@@ -615,6 +616,34 @@ pub fn canvas_action_meta(a: CanvasAction) -> HelpMeta {
         CanvasAction::CancelResize => HelpMeta {
             group: "Menus & Popups",
             description: "Resize cancel",
+        },
+        CanvasAction::CreateConnection => HelpMeta {
+            group: "Connections",
+            description: "Create connection from selected node",
+        },
+        CanvasAction::DeleteConnection => HelpMeta {
+            group: "Connections",
+            description: "Delete connection from selected node",
+        },
+        CanvasAction::DeleteAllConnections => HelpMeta {
+            group: "Connections",
+            description: "Delete all connections on selected node",
+        },
+        CanvasAction::RenameNode => HelpMeta {
+            group: "Editing",
+            description: "Rename selected node",
+        },
+        CanvasAction::ResizeMode => HelpMeta {
+            group: "Editing",
+            description: "Enter resize mode",
+        },
+        CanvasAction::SetColor => HelpMeta {
+            group: "Editing",
+            description: "Set color of selected node(s)",
+        },
+        CanvasAction::DeleteNode => HelpMeta {
+            group: "Editing",
+            description: "Delete selected node(s)",
         },
         CanvasAction::Help => HelpMeta {
             group: "General",

--- a/src/keybinds/help_meta.rs
+++ b/src/keybinds/help_meta.rs
@@ -645,6 +645,18 @@ pub fn canvas_action_meta(a: CanvasAction) -> HelpMeta {
             group: "Editing",
             description: "Delete selected node(s)",
         },
+        CanvasAction::AddTextNode => HelpMeta {
+            group: "Editing",
+            description: "Add text node at cursor",
+        },
+        CanvasAction::AddGroup => HelpMeta {
+            group: "Editing",
+            description: "Add group at cursor",
+        },
+        CanvasAction::AddImageNode => HelpMeta {
+            group: "Editing",
+            description: "Add image node at cursor",
+        },
         CanvasAction::Help => HelpMeta {
             group: "General",
             description: "Help",

--- a/src/keybinds/help_meta.rs
+++ b/src/keybinds/help_meta.rs
@@ -24,6 +24,7 @@ pub fn canvas_group_order() -> &'static [&'static str] {
     &[
         "Navigation",
         "Editing",
+        "Display",
         "Interface",
         "Menus & Popups",
         "General",
@@ -554,6 +555,10 @@ pub fn canvas_action_meta(a: CanvasAction) -> HelpMeta {
         CanvasAction::RenameConfirm => HelpMeta {
             group: "Editing",
             description: "Rename confirm",
+        },
+        CanvasAction::ToggleOrthogonal => HelpMeta {
+            group: "Display",
+            description: "Toggle orthogonal edge routing",
         },
         CanvasAction::RenameCancel => HelpMeta {
             group: "Editing",

--- a/src/keybinds/types.rs
+++ b/src/keybinds/types.rs
@@ -235,6 +235,7 @@ pub enum CanvasAction {
     EditOrConnect,
     OpenContextMenu,
     ToggleGrid,
+    ToggleOrthogonal,
     ToggleEditorPane,
     CycleFocus,
     Help,

--- a/src/keybinds/types.rs
+++ b/src/keybinds/types.rs
@@ -251,6 +251,13 @@ pub enum CanvasAction {
     CancelResize,
     EditorUnfocus,
     EditorSyncRaw,
+    CreateConnection,
+    DeleteConnection,
+    RenameNode,
+    ResizeMode,
+    SetColor,
+    DeleteNode,
+    DeleteAllConnections,
 }
 
 #[derive(

--- a/src/keybinds/types.rs
+++ b/src/keybinds/types.rs
@@ -221,6 +221,8 @@ pub enum DrawAction {
 #[serde(rename_all = "snake_case")]
 pub enum CanvasAction {
     Quit,
+    Undo,
+    Redo,
     Save,
     ZoomFineIn,
     ZoomFineOut,

--- a/src/keybinds/types.rs
+++ b/src/keybinds/types.rs
@@ -258,6 +258,9 @@ pub enum CanvasAction {
     SetColor,
     DeleteNode,
     DeleteAllConnections,
+    AddTextNode,
+    AddGroup,
+    AddImageNode,
 }
 
 #[derive(

--- a/src/local_state.rs
+++ b/src/local_state.rs
@@ -54,6 +54,8 @@ pub struct VaultState {
     /// Expanded folder paths for this vault.
     #[serde(default)]
     pub expanded_folders: BTreeSet<String>,
+    #[serde(default)]
+    pub canvas_orthogonal: bool,
 }
 
 impl LocalState {
@@ -291,6 +293,7 @@ mod tests {
             "/vault/path".into(),
             VaultState {
                 expanded_folders: ["a", "b"].into_iter().map(Into::into).collect(),
+                canvas_orthogonal: false,
             },
         );
         state.save(&path).unwrap();

--- a/src/pinstar/data.rs
+++ b/src/pinstar/data.rs
@@ -81,6 +81,17 @@ pub struct CanvasEdge {
     pub to_side: Option<String>,
     pub label: Option<String>,
     pub color: Option<String>,
+    #[serde(default)]
+    pub style: EdgeStyle,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum EdgeStyle {
+    #[default]
+    Solid,
+    Dashed,
+    Dotted,
 }
 
 impl CanvasNode {

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -552,113 +552,6 @@ fn execute_menu_action(
     state.sync_to_raw_editor();
 }
 
-fn handle_direct_action(
-    state: &mut PinstarState,
-    action: CanvasAction,
-    app: &mut crate::app::App,
-    area: ratatui::layout::Rect,
-) -> bool {
-    match action {
-        CanvasAction::CreateConnection => {
-            if state.selected_node_id.is_some() {
-                state.start_connection();
-            } else {
-                app.set_temporary_status("Select a node first to create a connection");
-            }
-        }
-        CanvasAction::DeleteConnection => {
-            if state.selected_node_id.is_some() {
-                state.start_delete_connection();
-            } else {
-                app.set_temporary_status("Select a node first to delete connections");
-            }
-        }
-        CanvasAction::RenameNode => {
-            if let Some(id) = state.selected_node_id.clone() {
-                let current_title = state
-                    .data
-                    .nodes
-                    .iter()
-                    .find(|n| n.id() == id)
-                    .and_then(|n| n.title())
-                    .unwrap_or("")
-                    .to_string();
-                let mut textarea = TextArea::from(vec![current_title]);
-                textarea.set_cursor_line_style(ratatui::style::Style::default());
-                textarea.set_block(
-                    ratatui::widgets::Block::default()
-                        .borders(ratatui::widgets::Borders::ALL)
-                        .title(" Rename Node - Enter to confirm, Esc to cancel "),
-                );
-                state.rename_popup = Some(textarea);
-            } else {
-                app.set_temporary_status("Select a node first to rename");
-            }
-        }
-        CanvasAction::ResizeMode => {
-            if state.selected_node_id.is_some() {
-                state.start_resize();
-            } else {
-                app.set_temporary_status("Select a node first to resize");
-            }
-        }
-        CanvasAction::SetColor => {
-            if state.selected_node_id.is_none()
-                && state.selected_edge_id.is_none()
-                && state.selected_node_ids.is_empty()
-            {
-                app.set_temporary_status("Select a node or edge first to set color");
-                return true;
-            }
-            let menu_x = (area.width / 2).saturating_sub(12);
-            let menu_y = area.height;
-            let mut items = vec!["Default".to_string()];
-            let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
-            for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
-                let capitalized = name
-                    .chars()
-                    .next()
-                    .unwrap_or(' ')
-                    .to_uppercase()
-                    .to_string()
-                    + &name[1..];
-                items.push(capitalized);
-                color_hints.push(Some(*color));
-            }
-            state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
-                x: menu_x,
-                y: menu_y,
-                selected: 0,
-                items,
-                color_hints,
-                menu_type: PinstarMenuType::ColorPicker,
-            });
-        }
-        CanvasAction::DeleteNode => {
-            state.delete_selected_node();
-            state.sync_to_raw_editor();
-        }
-        CanvasAction::DeleteAllConnections => {
-            state.delete_node_connections();
-            state.sync_to_raw_editor();
-        }
-        CanvasAction::AddTextNode => {
-            state.add_text_node(state.viewport_x, state.viewport_y);
-            state.sync_to_raw_editor();
-        }
-        CanvasAction::AddGroup => {
-            state.add_group(state.viewport_x, state.viewport_y);
-            state.sync_to_raw_editor();
-        }
-        CanvasAction::AddImageNode => {
-            state.add_image_node(state.viewport_x, state.viewport_y);
-            state.sync_to_raw_editor();
-        }
-        _ => {}
-    }
-    true
-}
-
 pub fn handle_pinstar_event(
     state: &mut PinstarState,
     key: KeyEvent,
@@ -690,7 +583,6 @@ pub fn handle_pinstar_event(
 
     let mut menu_action = None;
     let mut close_menu = false;
-    let mut direct_action: Option<CanvasAction> = None;
 
     if let Some(menu) = &mut state.context_menu {
         state.seq_matcher.clear();
@@ -710,47 +602,18 @@ pub fn handle_pinstar_event(
                 menu_action = Some((menu.selected, menu.menu_type, menu.x, menu.y));
                 close_menu = true;
             }
-            _ if keybinds.matches_canvas(CanvasAction::CreateConnection, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::CreateConnection);
+            _ => {
+                if let crossterm::event::KeyCode::Char(c) = key.code {
+                    let c = c.to_ascii_lowercase();
+                    if let Some(index) = menu.items.iter().position(|item| {
+                        crate::pinstar::state::menu_item_shortcut_char(menu.menu_type, item)
+                            == Some(c)
+                    }) {
+                        menu_action = Some((index, menu.menu_type, menu.x, menu.y));
+                        close_menu = true;
+                    }
+                }
             }
-            _ if keybinds.matches_canvas(CanvasAction::DeleteConnection, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::DeleteConnection);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::RenameNode, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::RenameNode);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::ResizeMode, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::ResizeMode);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::SetColor, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::SetColor);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::DeleteNode, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::DeleteNode);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::DeleteAllConnections, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::DeleteAllConnections);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::AddTextNode, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::AddTextNode);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::AddGroup, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::AddGroup);
-            }
-            _ if keybinds.matches_canvas(CanvasAction::AddImageNode, &key) => {
-                close_menu = true;
-                direct_action = Some(CanvasAction::AddImageNode);
-            }
-            _ => {}
         }
     }
 
@@ -761,12 +624,8 @@ pub fn handle_pinstar_event(
     if let Some((selected, menu_type, mx, my)) = menu_action {
         execute_menu_action(state, selected, menu_type, mx, my);
         return true;
-    } else if close_menu && direct_action.is_none() {
+    } else if close_menu {
         return true;
-    }
-
-    if let Some(action) = direct_action {
-        return handle_direct_action(state, action, app, area);
     }
 
     if state.context_menu.is_some() {
@@ -1033,23 +892,36 @@ pub fn handle_pinstar_event(
                         items.push(capitalized);
                         color_hints.push(Some(*color));
                     }
+                    let picker_type = if state.selected_edge_id.is_some() {
+                        PinstarMenuType::EdgeColorPicker
+                    } else {
+                        PinstarMenuType::ColorPicker
+                    };
                     state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
                         x: menu_x,
                         y: menu_y,
                         selected: 0,
                         items,
                         color_hints,
-                        menu_type: PinstarMenuType::ColorPicker,
+                        menu_type: picker_type,
                     });
                 }
             }
             CanvasAction::DeleteNode => {
-                state.delete_selected_node();
-                state.sync_to_raw_editor();
+                if state.all_selected_node_ids().is_empty() {
+                    app.set_temporary_status("Select a node first to delete");
+                } else {
+                    state.delete_selected_node();
+                    state.sync_to_raw_editor();
+                }
             }
             CanvasAction::DeleteAllConnections => {
-                state.delete_node_connections();
-                state.sync_to_raw_editor();
+                if state.all_selected_node_ids().is_empty() {
+                    app.set_temporary_status("Select a node first to clear connections");
+                } else {
+                    state.delete_node_connections();
+                    state.sync_to_raw_editor();
+                }
             }
             CanvasAction::AddTextNode => {
                 state.add_text_node(state.viewport_x, state.viewport_y);

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -84,8 +84,13 @@ pub fn handle_pinstar_mouse(
             }
             if !state.mouse_dragged {
                 let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
-                state.select_node_at(cx, cy);
-                state.open_context_menu(mouse.column, mouse.row, cx, cy);
+                // Edge hit takes precedence over node hit
+                if state.select_edge_at(cx, cy).is_some() {
+                    state.open_edge_context_menu(mouse.column, mouse.row);
+                } else {
+                    state.select_node_at(cx, cy);
+                    state.open_context_menu(mouse.column, mouse.row, cx, cy);
+                }
             }
             state.drag_start_pos = None;
             true
@@ -412,6 +417,68 @@ fn execute_menu_action(
             state.set_node_color(Some(entry.1.to_string()));
         }
         state.sync_to_raw_editor();
+        return;
+    }
+
+    if menu_type == PinstarMenuType::EdgeMenu {
+        match selected_index {
+            0 => {
+                let mut items = vec!["Default".to_string()];
+                for (name, _, _) in crate::pinstar::COLOR_PICKER_PALETTE {
+                    let capitalized = name
+                        .chars()
+                        .next()
+                        .unwrap_or(' ')
+                        .to_uppercase()
+                        .to_string()
+                        + &name[1..];
+                    items.push(capitalized);
+                }
+                state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
+                    x: menu_x,
+                    y: menu_y,
+                    selected: 0,
+                    items,
+                    menu_type: PinstarMenuType::EdgeColorPicker,
+                });
+            }
+            1 => {
+                state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
+                    x: menu_x,
+                    y: menu_y,
+                    selected: 0,
+                    items: vec![
+                        "Solid".to_string(),
+                        "Dashed".to_string(),
+                        "Dotted".to_string(),
+                    ],
+                    menu_type: PinstarMenuType::EdgeStylePicker,
+                });
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    if menu_type == PinstarMenuType::EdgeColorPicker {
+        if selected_index == 0 {
+            state.set_edge_color(None);
+        } else if let Some(entry) = crate::pinstar::COLOR_PICKER_PALETTE.get(selected_index - 1) {
+            state.set_edge_color(Some(entry.1.to_string()));
+        }
+        state.selected_edge_id = None;
+        return;
+    }
+
+    if menu_type == PinstarMenuType::EdgeStylePicker {
+        let style = match selected_index {
+            0 => crate::pinstar::data::EdgeStyle::Solid,
+            1 => crate::pinstar::data::EdgeStyle::Dashed,
+            2 => crate::pinstar::data::EdgeStyle::Dotted,
+            _ => return,
+        };
+        state.set_edge_style(style);
+        state.selected_edge_id = None;
         return;
     }
 

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -173,6 +173,21 @@ pub fn handle_pinstar_mouse(
                 return true;
             }
 
+            // Edge-list overlay: clicking a row selects that edge and opens its
+            // context menu. Only when no menu is already open.
+            if state.context_menu.is_none()
+                && let Some(ov) = state.edge_overlay_rect
+                && mouse.column > ov.x
+                && mouse.column < ov.x + ov.width.saturating_sub(1)
+                && mouse.row > ov.y
+                && mouse.row < ov.y + ov.height.saturating_sub(1)
+            {
+                let row = mouse.row as usize - ov.y as usize - 1;
+                if state.select_edge_of_selected_node(row + 1).is_some() {
+                    state.open_edge_menu_centered(area);
+                }
+                return true;
+            }
             if let Some(floating_area) = state.floating_editor_rect
                 && let Some(editor) = &mut state.floating_editor
                 && crate::events::contains_cell(floating_area, mouse.column, mouse.row)
@@ -713,6 +728,21 @@ pub fn handle_pinstar_event(
         return true;
     }
 
+    // Edge-list overlay shortcuts: digits 1..n select the corresponding edge
+    // connected to the selected node and open its context menu. Only when not
+    // in a transient mode.
+    if let crossterm::event::KeyCode::Char(c) = key.code
+        && c.is_ascii_digit()
+        && state.connection_source_id.is_none()
+        && state.deleting_connection_source_id.is_none()
+        && state.resizing_node_id.is_none()
+    {
+        let idx = (c as u8 - b'0') as usize;
+        if state.select_edge_of_selected_node(idx).is_some() {
+            state.open_edge_menu_centered(area);
+            return true;
+        }
+    }
     // Connection / delete-connection mode: Enter/i completes the operation on
     // the selected node. Checked explicitly because Enter also binds to
     // RenameConfirm/MenuSelect/ConfirmResize, making resolve_canvas

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -86,6 +86,10 @@ pub fn handle_pinstar_mouse(
                     state.open_edge_context_menu(mouse.column, mouse.row);
                 } else {
                     state.select_node_at(cx, cy);
+                    if state.selected_node_id.is_none() {
+                        state.selected_node_ids.clear();
+                        state.selected_edge_id = None;
+                    }
                     state.open_context_menu(mouse.column, mouse.row, cx, cy);
                 }
             }
@@ -271,6 +275,8 @@ pub fn handle_pinstar_mouse(
                 state.capture_drag_nodes();
                 state.last_click = Some((mouse.column, mouse.row, std::time::Instant::now()));
             } else {
+                state.selected_node_ids.clear();
+                state.selected_edge_id = None;
                 state.last_click = Some((mouse.column, mouse.row, std::time::Instant::now()));
             }
 
@@ -627,6 +633,18 @@ fn handle_direct_action(
         }
         CanvasAction::DeleteAllConnections => {
             state.delete_node_connections();
+            state.sync_to_raw_editor();
+        }
+        CanvasAction::AddTextNode => {
+            state.add_text_node(state.viewport_x, state.viewport_y);
+            state.sync_to_raw_editor();
+        }
+        CanvasAction::AddGroup => {
+            state.add_group(state.viewport_x, state.viewport_y);
+            state.sync_to_raw_editor();
+        }
+        CanvasAction::AddImageNode => {
+            state.add_image_node(state.viewport_x, state.viewport_y);
             state.sync_to_raw_editor();
         }
         _ => {}
@@ -1004,6 +1022,18 @@ pub fn handle_pinstar_event(
             }
             CanvasAction::DeleteAllConnections => {
                 state.delete_node_connections();
+                state.sync_to_raw_editor();
+            }
+            CanvasAction::AddTextNode => {
+                state.add_text_node(state.viewport_x, state.viewport_y);
+                state.sync_to_raw_editor();
+            }
+            CanvasAction::AddGroup => {
+                state.add_group(state.viewport_x, state.viewport_y);
+                state.sync_to_raw_editor();
+            }
+            CanvasAction::AddImageNode => {
+                state.add_image_node(state.viewport_x, state.viewport_y);
                 state.sync_to_raw_editor();
             }
             _ => {

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -713,6 +713,19 @@ pub fn handle_pinstar_event(
         return true;
     }
 
+    // Connection mode: Enter/i completes the connection to the selected node.
+    // Checked explicitly because Enter also binds to RenameConfirm/MenuSelect/
+    // ConfirmResize, making resolve_canvas non-deterministic for Enter.
+    if state.connection_source_id.is_some()
+        && keybinds.matches_canvas(CanvasAction::EditOrConnect, &key)
+    {
+        if let Some(target_id) = state.selected_node_id.clone() {
+            state.finish_connection(&target_id);
+        }
+        sync_mode_status(app, state);
+        return true;
+    }
+
     let seq = config.sequences_enabled();
     let counts = config.counts_enabled();
     if crate::events::is_universal_quit_key(&key) {

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -713,17 +713,25 @@ pub fn handle_pinstar_event(
         return true;
     }
 
-    // Connection mode: Enter/i completes the connection to the selected node.
-    // Checked explicitly because Enter also binds to RenameConfirm/MenuSelect/
-    // ConfirmResize, making resolve_canvas non-deterministic for Enter.
-    if state.connection_source_id.is_some()
-        && keybinds.matches_canvas(CanvasAction::EditOrConnect, &key)
-    {
-        if let Some(target_id) = state.selected_node_id.clone() {
-            state.finish_connection(&target_id);
+    // Connection / delete-connection mode: Enter/i completes the operation on
+    // the selected node. Checked explicitly because Enter also binds to
+    // RenameConfirm/MenuSelect/ConfirmResize, making resolve_canvas
+    // non-deterministic for Enter.
+    if keybinds.matches_canvas(CanvasAction::EditOrConnect, &key) {
+        if state.connection_source_id.is_some() {
+            if let Some(target_id) = state.selected_node_id.clone() {
+                state.finish_connection(&target_id);
+            }
+            sync_mode_status(app, state);
+            return true;
         }
-        sync_mode_status(app, state);
-        return true;
+        if state.deleting_connection_source_id.is_some() {
+            if let Some(target_id) = state.selected_node_id.clone() {
+                state.finish_delete_connection(&target_id);
+            }
+            sync_mode_status(app, state);
+            return true;
+        }
     }
 
     let seq = config.sequences_enabled();

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -600,6 +600,12 @@ pub fn handle_pinstar_event(
             CanvasAction::Save => {
                 let _ = state.save();
             }
+            CanvasAction::Undo => {
+                let _ = state.undo();
+            }
+            CanvasAction::Redo => {
+                let _ = state.redo();
+            }
             CanvasAction::ZoomFineIn => {
                 state.zoom_in();
             }

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -603,6 +603,13 @@ fn handle_direct_action(
             }
         }
         CanvasAction::SetColor => {
+            if state.selected_node_id.is_none()
+                && state.selected_edge_id.is_none()
+                && state.selected_node_ids.is_empty()
+            {
+                app.set_temporary_status("Select a node or edge first to set color");
+                return true;
+            }
             let menu_x = (area.width / 2).saturating_sub(12);
             let menu_y = area.height;
             let mut items = vec!["Default".to_string()];
@@ -730,6 +737,18 @@ pub fn handle_pinstar_event(
             _ if keybinds.matches_canvas(CanvasAction::DeleteAllConnections, &key) => {
                 close_menu = true;
                 direct_action = Some(CanvasAction::DeleteAllConnections);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::AddTextNode, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::AddTextNode);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::AddGroup, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::AddGroup);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::AddImageNode, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::AddImageNode);
             }
             _ => {}
         }
@@ -911,11 +930,12 @@ pub fn handle_pinstar_event(
             }
             CanvasAction::ToggleOrthogonal => {
                 state.orthogonal_connections = !state.orthogonal_connections;
-                state.footer_hint = if state.orthogonal_connections {
-                    "arrow:on".into()
+                let status = if state.orthogonal_connections {
+                    "Orthogonal connections: on"
                 } else {
-                    "arrow:off".into()
+                    "Orthogonal connections: off"
                 };
+                app.set_temporary_status(status);
                 // Persist per-vault
                 if let Ok(vault_id) = crate::local_state::vault_identity_path(&app.storage.data_dir)
                 {
@@ -992,29 +1012,36 @@ pub fn handle_pinstar_event(
                 }
             }
             CanvasAction::SetColor => {
-                let menu_x = (area.width / 2).saturating_sub(12);
-                let menu_y = area.height;
-                let mut items = vec!["Default".to_string()];
-                let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
-                for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
-                    let capitalized = name
-                        .chars()
-                        .next()
-                        .unwrap_or(' ')
-                        .to_uppercase()
-                        .to_string()
-                        + &name[1..];
-                    items.push(capitalized);
-                    color_hints.push(Some(*color));
+                if state.selected_node_id.is_none()
+                    && state.selected_edge_id.is_none()
+                    && state.selected_node_ids.is_empty()
+                {
+                    app.set_temporary_status("Select a node or edge first to set color");
+                } else {
+                    let menu_x = (area.width / 2).saturating_sub(12);
+                    let menu_y = area.height;
+                    let mut items = vec!["Default".to_string()];
+                    let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
+                    for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
+                        let capitalized = name
+                            .chars()
+                            .next()
+                            .unwrap_or(' ')
+                            .to_uppercase()
+                            .to_string()
+                            + &name[1..];
+                        items.push(capitalized);
+                        color_hints.push(Some(*color));
+                    }
+                    state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
+                        x: menu_x,
+                        y: menu_y,
+                        selected: 0,
+                        items,
+                        color_hints,
+                        menu_type: PinstarMenuType::ColorPicker,
+                    });
                 }
-                state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
-                    x: menu_x,
-                    y: menu_y,
-                    selected: 0,
-                    items,
-                    color_hints,
-                    menu_type: PinstarMenuType::ColorPicker,
-                });
             }
             CanvasAction::DeleteNode => {
                 state.delete_selected_node();

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -53,7 +53,41 @@ pub fn handle_pinstar_mouse(
 
             let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
             state.select_node_at(cx, cy);
-            state.open_context_menu(mouse.column, mouse.row, cx, cy);
+            state.mouse_dragged = false;
+            state.select_rect_start = Some((cx, cy));
+            state.drag_start_pos = Some((cx, cy));
+            true
+        }
+        MouseEventKind::Drag(MouseButton::Right) => {
+            state.mouse_dragged = true;
+            if state.connection_source_id.is_none()
+                && state.deleting_connection_source_id.is_none()
+                && state.resizing_node_id.is_none()
+                && state.selected_node_id.is_none()
+            {
+                let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
+                state.mouse_selecting = true;
+                state.select_rect_end = Some((cx, cy));
+                if let Some(start) = state.select_rect_start {
+                    state.select_nodes_in_rect(start.0, start.1, cx, cy);
+                }
+            }
+            true
+        }
+        MouseEventKind::Up(MouseButton::Right) => {
+            if state.mouse_selecting {
+                state.mouse_selecting = false;
+                state.select_rect_start = None;
+                state.select_rect_end = None;
+                state.drag_start_pos = None;
+                return true;
+            }
+            if !state.mouse_dragged {
+                let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
+                state.select_node_at(cx, cy);
+                state.open_context_menu(mouse.column, mouse.row, cx, cy);
+            }
+            state.drag_start_pos = None;
             true
         }
         MouseEventKind::Down(MouseButton::Middle) => {
@@ -427,16 +461,7 @@ fn execute_menu_action(
                 });
             }
             5 => state.delete_node_connections(),
-            6 => {
-                let id_clone = id.clone();
-                state.data.nodes.retain(|n| n.id() != id_clone);
-                state
-                    .data
-                    .edges
-                    .retain(|e| e.from_node != id_clone && e.to_node != id_clone);
-                state.selected_node_id = None;
-                let _ = state.save();
-            }
+            6 => state.delete_selected_node(),
             _ => {}
         }
     } else {

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -805,6 +805,79 @@ pub fn handle_pinstar_event(
                 state.help_requested = true;
                 *running = false;
             }
+            CanvasAction::CreateConnection => {
+                if state.selected_node_id.is_some() {
+                    state.start_connection();
+                } else {
+                    app.set_temporary_status("Select a node first to create a connection");
+                }
+            }
+            CanvasAction::DeleteConnection => {
+                if state.selected_node_id.is_some() {
+                    state.start_delete_connection();
+                } else {
+                    app.set_temporary_status("Select a node first to delete connections");
+                }
+            }
+            CanvasAction::RenameNode => {
+                if let Some(id) = state.selected_node_id.clone() {
+                    let current_title = state
+                        .data
+                        .nodes
+                        .iter()
+                        .find(|n| n.id() == id)
+                        .and_then(|n| n.title())
+                        .unwrap_or("")
+                        .to_string();
+                    let mut textarea = TextArea::from(vec![current_title]);
+                    textarea.set_cursor_line_style(ratatui::style::Style::default());
+                    textarea.set_block(
+                        ratatui::widgets::Block::default()
+                            .borders(ratatui::widgets::Borders::ALL)
+                            .title(" Rename Node - Enter to confirm, Esc to cancel "),
+                    );
+                    state.rename_popup = Some(textarea);
+                } else {
+                    app.set_temporary_status("Select a node first to rename");
+                }
+            }
+            CanvasAction::ResizeMode => {
+                if state.selected_node_id.is_some() {
+                    state.start_resize();
+                } else {
+                    app.set_temporary_status("Select a node first to resize");
+                }
+            }
+            CanvasAction::SetColor => {
+                let menu_x = (area.width / 2).saturating_sub(12);
+                let menu_y = area.height;
+                let mut items = vec!["Default".to_string()];
+                for (name, _, _) in crate::pinstar::COLOR_PICKER_PALETTE {
+                    let capitalized = name
+                        .chars()
+                        .next()
+                        .unwrap_or(' ')
+                        .to_uppercase()
+                        .to_string()
+                        + &name[1..];
+                    items.push(capitalized);
+                }
+                state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
+                    x: menu_x,
+                    y: menu_y,
+                    selected: 0,
+                    items,
+                    menu_type: PinstarMenuType::ColorPicker,
+                });
+            }
+            CanvasAction::DeleteNode => {
+                state.delete_selected_node();
+                state.sync_to_raw_editor();
+            }
+            CanvasAction::DeleteAllConnections => {
+                state.delete_node_connections();
+                state.sync_to_raw_editor();
+            }
             _ => {
                 if keybinds.matches_canvas(CanvasAction::Quit, &key) {
                     *running = false;

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -766,6 +766,30 @@ pub fn handle_pinstar_event(
             CanvasAction::ToggleGrid => {
                 state.show_grid = !state.show_grid;
             }
+            CanvasAction::ToggleOrthogonal => {
+                state.orthogonal_connections = !state.orthogonal_connections;
+                state.footer_hint = if state.orthogonal_connections {
+                    "arrow:on".into()
+                } else {
+                    "arrow:off".into()
+                };
+                // Persist per-vault
+                if let Ok(vault_id) = crate::local_state::vault_identity_path(&app.storage.data_dir)
+                {
+                    let vault_key = vault_id.to_string_lossy().into_owned();
+                    if let Ok(paths) = crate::paths::AppPaths::discover(
+                        crate::config::ClinConfig::config_path().unwrap_or_default(),
+                    ) {
+                        let _ = crate::local_state::LocalState::update(&paths.state_path(), |s| {
+                            s.vaults
+                                .entry(vault_key.clone())
+                                .or_default()
+                                .canvas_orthogonal = state.orthogonal_connections;
+                            Ok(())
+                        });
+                    }
+                }
+            }
             CanvasAction::ToggleEditorPane => {
                 state.show_editor_pane = !state.show_editor_pane;
                 if !state.show_editor_pane {

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -4,6 +4,23 @@ use crate::text_edit::apply_text_shortcuts;
 use crossterm::event::{KeyEvent, MouseButton, MouseEvent, MouseEventKind};
 use ratatui_textarea::{Input, TextArea};
 
+/// Sync the header-bar status with the active canvas mode (connection /
+/// delete-connection / resize). Called after any mode transition.
+fn sync_mode_status(app: &mut crate::app::App, state: &PinstarState) {
+    const MODE_MESSAGES: [&str; 3] = [
+        "CONNECTION MODE: Select target node with mouse or Enter",
+        "DELETE CONNECTION MODE: Select target node to remove link",
+        "RESIZE MODE: Drag mouse to resize, Left-click to confirm",
+    ];
+    if let Some(msg) = state.active_mode_message() {
+        app.status = std::borrow::Cow::Borrowed(msg);
+        app.status_until = None;
+    } else if MODE_MESSAGES.contains(&app.status.as_ref()) {
+        // Clear a stale mode message only; leave temporary statuses alone.
+        app.set_default_status();
+    }
+}
+
 pub fn handle_pinstar_mouse(
     state: &mut PinstarState,
     mouse: MouseEvent,
@@ -39,6 +56,7 @@ pub fn handle_pinstar_mouse(
                 state.is_dragging_resize_handle = false;
                 let _ = state.save();
                 state.sync_to_raw_editor();
+                sync_mode_status(app, state);
                 return true;
             }
 
@@ -151,6 +169,7 @@ pub fn handle_pinstar_mouse(
 
             if let Some((selected, menu_type, mx, my)) = menu_action {
                 execute_menu_action(state, selected, menu_type, mx, my);
+                sync_mode_status(app, state);
                 return true;
             }
 
@@ -208,6 +227,7 @@ pub fn handle_pinstar_mouse(
                 } else {
                     state.connection_source_id = None;
                 }
+                sync_mode_status(app, state);
                 return true;
             }
 
@@ -217,6 +237,7 @@ pub fn handle_pinstar_mouse(
                 } else {
                     state.deleting_connection_source_id = None;
                 }
+                sync_mode_status(app, state);
                 return true;
             }
 
@@ -623,6 +644,7 @@ pub fn handle_pinstar_event(
 
     if let Some((selected, menu_type, mx, my)) = menu_action {
         execute_menu_action(state, selected, menu_type, mx, my);
+        sync_mode_status(app, state);
         return true;
     } else if close_menu {
         return true;
@@ -671,6 +693,7 @@ pub fn handle_pinstar_event(
                 state.resizing_node_id = None;
                 state.is_dragging_resize_handle = false;
                 let _ = state.save();
+                sync_mode_status(app, state);
                 return true;
             }
             _ => {}
@@ -698,6 +721,7 @@ pub fn handle_pinstar_event(
         } else {
             *running = false;
         }
+        sync_mode_status(app, state);
         return true;
     }
 
@@ -945,5 +969,6 @@ pub fn handle_pinstar_event(
         crate::keybinds::MatchOutcome::NoMatch => return false,
     }
 
+    sync_mode_status(app, state);
     true
 }

--- a/src/pinstar/input.rs
+++ b/src/pinstar/input.rs
@@ -52,10 +52,8 @@ pub fn handle_pinstar_mouse(
             }
 
             let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
-            state.select_node_at(cx, cy);
             state.mouse_dragged = false;
             state.select_rect_start = Some((cx, cy));
-            state.drag_start_pos = Some((cx, cy));
             true
         }
         MouseEventKind::Drag(MouseButton::Right) => {
@@ -63,7 +61,6 @@ pub fn handle_pinstar_mouse(
             if state.connection_source_id.is_none()
                 && state.deleting_connection_source_id.is_none()
                 && state.resizing_node_id.is_none()
-                && state.selected_node_id.is_none()
             {
                 let (cx, cy) = state.screen_to_canvas(mouse.column, mouse.row, canvas_area);
                 state.mouse_selecting = true;
@@ -424,7 +421,8 @@ fn execute_menu_action(
         match selected_index {
             0 => {
                 let mut items = vec!["Default".to_string()];
-                for (name, _, _) in crate::pinstar::COLOR_PICKER_PALETTE {
+                let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
+                for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
                     let capitalized = name
                         .chars()
                         .next()
@@ -433,12 +431,14 @@ fn execute_menu_action(
                         .to_string()
                         + &name[1..];
                     items.push(capitalized);
+                    color_hints.push(Some(*color));
                 }
                 state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
                     x: menu_x,
                     y: menu_y,
                     selected: 0,
                     items,
+                    color_hints,
                     menu_type: PinstarMenuType::EdgeColorPicker,
                 });
             }
@@ -452,6 +452,7 @@ fn execute_menu_action(
                         "Dashed".to_string(),
                         "Dotted".to_string(),
                     ],
+                    color_hints: Vec::new(),
                     menu_type: PinstarMenuType::EdgeStylePicker,
                 });
             }
@@ -509,7 +510,8 @@ fn execute_menu_action(
             3 => state.start_resize(),
             4 => {
                 let mut items = vec!["Default".to_string()];
-                for (name, _, _) in crate::pinstar::COLOR_PICKER_PALETTE {
+                let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
+                for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
                     let capitalized = name
                         .chars()
                         .next()
@@ -518,12 +520,14 @@ fn execute_menu_action(
                         .to_string()
                         + &name[1..];
                     items.push(capitalized);
+                    color_hints.push(Some(*color));
                 }
                 state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
                     x: menu_x,
                     y: menu_y,
                     selected: 0,
                     items,
+                    color_hints,
                     menu_type: PinstarMenuType::ColorPicker,
                 });
             }
@@ -540,6 +544,94 @@ fn execute_menu_action(
         }
     }
     state.sync_to_raw_editor();
+}
+
+fn handle_direct_action(
+    state: &mut PinstarState,
+    action: CanvasAction,
+    app: &mut crate::app::App,
+    area: ratatui::layout::Rect,
+) -> bool {
+    match action {
+        CanvasAction::CreateConnection => {
+            if state.selected_node_id.is_some() {
+                state.start_connection();
+            } else {
+                app.set_temporary_status("Select a node first to create a connection");
+            }
+        }
+        CanvasAction::DeleteConnection => {
+            if state.selected_node_id.is_some() {
+                state.start_delete_connection();
+            } else {
+                app.set_temporary_status("Select a node first to delete connections");
+            }
+        }
+        CanvasAction::RenameNode => {
+            if let Some(id) = state.selected_node_id.clone() {
+                let current_title = state
+                    .data
+                    .nodes
+                    .iter()
+                    .find(|n| n.id() == id)
+                    .and_then(|n| n.title())
+                    .unwrap_or("")
+                    .to_string();
+                let mut textarea = TextArea::from(vec![current_title]);
+                textarea.set_cursor_line_style(ratatui::style::Style::default());
+                textarea.set_block(
+                    ratatui::widgets::Block::default()
+                        .borders(ratatui::widgets::Borders::ALL)
+                        .title(" Rename Node - Enter to confirm, Esc to cancel "),
+                );
+                state.rename_popup = Some(textarea);
+            } else {
+                app.set_temporary_status("Select a node first to rename");
+            }
+        }
+        CanvasAction::ResizeMode => {
+            if state.selected_node_id.is_some() {
+                state.start_resize();
+            } else {
+                app.set_temporary_status("Select a node first to resize");
+            }
+        }
+        CanvasAction::SetColor => {
+            let menu_x = (area.width / 2).saturating_sub(12);
+            let menu_y = area.height;
+            let mut items = vec!["Default".to_string()];
+            let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
+            for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
+                let capitalized = name
+                    .chars()
+                    .next()
+                    .unwrap_or(' ')
+                    .to_uppercase()
+                    .to_string()
+                    + &name[1..];
+                items.push(capitalized);
+                color_hints.push(Some(*color));
+            }
+            state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
+                x: menu_x,
+                y: menu_y,
+                selected: 0,
+                items,
+                color_hints,
+                menu_type: PinstarMenuType::ColorPicker,
+            });
+        }
+        CanvasAction::DeleteNode => {
+            state.delete_selected_node();
+            state.sync_to_raw_editor();
+        }
+        CanvasAction::DeleteAllConnections => {
+            state.delete_node_connections();
+            state.sync_to_raw_editor();
+        }
+        _ => {}
+    }
+    true
 }
 
 pub fn handle_pinstar_event(
@@ -573,6 +665,7 @@ pub fn handle_pinstar_event(
 
     let mut menu_action = None;
     let mut close_menu = false;
+    let mut direct_action: Option<CanvasAction> = None;
 
     if let Some(menu) = &mut state.context_menu {
         state.seq_matcher.clear();
@@ -592,6 +685,34 @@ pub fn handle_pinstar_event(
                 menu_action = Some((menu.selected, menu.menu_type, menu.x, menu.y));
                 close_menu = true;
             }
+            _ if keybinds.matches_canvas(CanvasAction::CreateConnection, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::CreateConnection);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::DeleteConnection, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::DeleteConnection);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::RenameNode, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::RenameNode);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::ResizeMode, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::ResizeMode);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::SetColor, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::SetColor);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::DeleteNode, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::DeleteNode);
+            }
+            _ if keybinds.matches_canvas(CanvasAction::DeleteAllConnections, &key) => {
+                close_menu = true;
+                direct_action = Some(CanvasAction::DeleteAllConnections);
+            }
             _ => {}
         }
     }
@@ -603,8 +724,12 @@ pub fn handle_pinstar_event(
     if let Some((selected, menu_type, mx, my)) = menu_action {
         execute_menu_action(state, selected, menu_type, mx, my);
         return true;
-    } else if close_menu {
+    } else if close_menu && direct_action.is_none() {
         return true;
+    }
+
+    if let Some(action) = direct_action {
+        return handle_direct_action(state, action, app, area);
     }
 
     if state.context_menu.is_some() {
@@ -852,7 +977,8 @@ pub fn handle_pinstar_event(
                 let menu_x = (area.width / 2).saturating_sub(12);
                 let menu_y = area.height;
                 let mut items = vec!["Default".to_string()];
-                for (name, _, _) in crate::pinstar::COLOR_PICKER_PALETTE {
+                let mut color_hints: Vec<Option<ratatui::style::Color>> = vec![None];
+                for (name, _, color) in crate::pinstar::COLOR_PICKER_PALETTE {
                     let capitalized = name
                         .chars()
                         .next()
@@ -861,12 +987,14 @@ pub fn handle_pinstar_event(
                         .to_string()
                         + &name[1..];
                     items.push(capitalized);
+                    color_hints.push(Some(*color));
                 }
                 state.context_menu = Some(crate::pinstar::state::PinstarContextMenu {
                     x: menu_x,
                     y: menu_y,
                     selected: 0,
                     items,
+                    color_hints,
                     menu_type: PinstarMenuType::ColorPicker,
                 });
             }

--- a/src/pinstar/mod.rs
+++ b/src/pinstar/mod.rs
@@ -13,4 +13,7 @@ pub const COLOR_PICKER_PALETTE: &[(&str, &str, Color)] = &[
     ("green", "#4caf50", Color::Rgb(76, 175, 80)),
     ("cyan", "#00bcd4", Color::Rgb(0, 188, 212)),
     ("purple", "#9c27b0", Color::Rgb(156, 39, 176)),
+    ("blue", "#2196f3", Color::Rgb(33, 150, 243)),
+    ("magenta", "#e91e63", Color::Rgb(233, 30, 99)),
+    ("white", "#ffffff", Color::Rgb(255, 255, 255)),
 ];

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -123,34 +123,12 @@ fn draw_braille_segment(
 }
 
 fn menu_shortcut(
-    keybinds: &crate::keybinds::Keybinds,
+    _keybinds: &crate::keybinds::Keybinds,
     menu_type: crate::pinstar::state::PinstarMenuType,
     item: &str,
 ) -> Option<String> {
-    use crate::keybinds::CanvasAction;
-    let action = match menu_type {
-        crate::pinstar::state::PinstarMenuType::Canvas => match item {
-            "Create Connection" => Some(CanvasAction::CreateConnection),
-            "Delete Connection" => Some(CanvasAction::DeleteConnection),
-            "Rename Node" => Some(CanvasAction::RenameNode),
-            "Resize Node" => Some(CanvasAction::ResizeMode),
-            "Set Color..." => Some(CanvasAction::SetColor),
-            "Delete All Connections" => Some(CanvasAction::DeleteAllConnections),
-            "Delete Node" => Some(CanvasAction::DeleteNode),
-            "Add Text Node" => Some(CanvasAction::AddTextNode),
-            "Add Group" => Some(CanvasAction::AddGroup),
-            "Add Image Node" => Some(CanvasAction::AddImageNode),
-            _ => None,
-        },
-        _ => None,
-    };
-    action.and_then(|a| {
-        let display = keybinds.canvas_keys_display(a);
-        let first = display.split('/').next().unwrap_or("").trim().to_string();
-        if first.is_empty() { None } else { Some(first) }
-    })
+    crate::pinstar::state::menu_item_shortcut_char(menu_type, item).map(|c| format!("[{c}]"))
 }
-
 pub fn draw_pinstar_view(
     frame: &mut Frame,
     state: &mut PinstarState,

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -76,6 +76,28 @@ fn get_edge_color(color: Option<&str>, selected: bool, theme: &AppThemeColors) -
         _ => theme.muted,
     }
 }
+
+/// Color for an edge's text in the overlay: the edge's own color when set,
+/// else the default text color.
+fn edge_overlay_color(color: Option<&str>, theme: &AppThemeColors) -> Color {
+    match color {
+        Some(s) if s.starts_with('#') && s.len() == 7 => {
+            let r = u8::from_str_radix(&s[1..3], 16).unwrap_or(0);
+            let g = u8::from_str_radix(&s[3..5], 16).unwrap_or(0);
+            let b = u8::from_str_radix(&s[5..7], 16).unwrap_or(0);
+            Color::Rgb(r, g, b)
+        }
+        _ => theme.text,
+    }
+}
+
+/// A resolved row for the edge-list overlay.
+struct OverlayEdgeRow {
+    index: usize,
+    from_title: Option<String>,
+    to_title: Option<String>,
+    color: Option<String>,
+}
 #[allow(clippy::too_many_arguments)]
 fn draw_braille_segment(
     buf: &mut ratatui::buffer::Buffer,
@@ -737,20 +759,45 @@ pub fn draw_pinstar_view(
             }
         }
     }
-
     // Edge-list overlay: when a node is selected, list its connected edges
-    // (1..n with from->to) in a bottom-right legend panel for keyboard/mouse
-    // edge access.
+    // (1..n) in a bottom-right legend panel, titles colored by edge color.
     if state.selected_node_id.is_some() {
         let edges = state.selected_node_edges();
         if !edges.is_empty() {
-            let max_len = edges
+            let no_title = "(no title)".to_string();
+            let resolved: Vec<OverlayEdgeRow> = edges
                 .iter()
                 .enumerate()
                 .map(|(i, e)| {
-                    format!("{} {} → {}", i + 1, e.from_node, e.to_node)
-                        .chars()
-                        .count()
+                    let title_of = |id: &str| {
+                        state
+                            .data
+                            .nodes
+                            .iter()
+                            .find(|n| n.id() == id)
+                            .and_then(|n| n.title())
+                            .map(|t| t.to_string())
+                    };
+                    OverlayEdgeRow {
+                        index: i,
+                        from_title: title_of(&e.from_node),
+                        to_title: title_of(&e.to_node),
+                        color: e.color.clone(),
+                    }
+                })
+                .collect();
+
+            let max_len = resolved
+                .iter()
+                .map(|r| {
+                    format!(
+                        "{} {} → {}",
+                        r.index + 1,
+                        r.from_title.as_deref().unwrap_or(no_title.as_str()),
+                        r.to_title.as_deref().unwrap_or(no_title.as_str())
+                    )
+                    .chars()
+                    .count()
                 })
                 .max()
                 .unwrap_or(0);
@@ -762,24 +809,37 @@ pub fn draw_pinstar_view(
                 overlay_width,
                 overlay_height,
             );
-            let rows: Vec<ratatui::text::Line> = edges
-                .iter()
-                .enumerate()
-                .map(|(i, e)| {
-                    ratatui::text::Line::from(vec![
-                        Span::styled(
-                            format!("{} ", i + 1),
+            let rows: Vec<ratatui::text::Line> =
+                resolved
+                    .iter()
+                    .map(|r| {
+                        let edge_color = edge_overlay_color(r.color.as_deref(), theme);
+                        let mut spans = vec![Span::styled(
+                            format!("{} ", r.index + 1),
                             Style::default()
                                 .fg(theme.accent)
                                 .add_modifier(Modifier::BOLD),
-                        ),
-                        Span::styled(
-                            format!("{} → {}", e.from_node, e.to_node),
-                            Style::default().fg(theme.text),
-                        ),
-                    ])
-                })
-                .collect();
+                        )];
+                        match &r.from_title {
+                            Some(title) => spans
+                                .push(Span::styled(title.clone(), Style::default().fg(edge_color))),
+                            None => spans.push(Span::styled(
+                                no_title.clone(),
+                                Style::default().fg(theme.muted),
+                            )),
+                        }
+                        spans.push(Span::styled(" → ", Style::default().fg(theme.muted)));
+                        match &r.to_title {
+                            Some(title) => spans
+                                .push(Span::styled(title.clone(), Style::default().fg(edge_color))),
+                            None => spans.push(Span::styled(
+                                no_title.clone(),
+                                Style::default().fg(theme.muted),
+                            )),
+                        }
+                        ratatui::text::Line::from(spans)
+                    })
+                    .collect();
             let overlay = Paragraph::new(rows).block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -789,6 +849,21 @@ pub fn draw_pinstar_view(
             );
             frame.render_widget(Clear, overlay_rect);
             frame.render_widget(overlay, overlay_rect);
+            // Hover highlight on overlay rows.
+            let hover_inner = Rect::new(
+                overlay_rect.x + 1,
+                overlay_rect.y + 1,
+                overlay_rect.width.saturating_sub(2),
+                overlay_rect.height.saturating_sub(2),
+            );
+            crate::ui::paint_list_hover(
+                frame,
+                hover_inner,
+                &ratatui::widgets::ListState::default(),
+                edges.len(),
+                mouse_pos,
+                theme.hover_style(),
+            );
             state.edge_overlay_rect = Some(overlay_rect);
         }
     }

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -122,6 +122,36 @@ fn draw_braille_segment(
     }
 }
 
+fn menu_shortcut(
+    keybinds: &crate::keybinds::Keybinds,
+    menu_type: crate::pinstar::state::PinstarMenuType,
+    item: &str,
+) -> Option<String> {
+    use crate::keybinds::CanvasAction;
+    let action = match menu_type {
+        crate::pinstar::state::PinstarMenuType::Canvas => match item {
+            "Create Connection" => Some(CanvasAction::CreateConnection),
+            "Delete Connection" => Some(CanvasAction::DeleteConnection),
+            "Rename Node" => Some(CanvasAction::RenameNode),
+            "Resize Node" => Some(CanvasAction::ResizeMode),
+            "Set Color..." => Some(CanvasAction::SetColor),
+            "Delete All Connections" => Some(CanvasAction::DeleteAllConnections),
+            "Delete Node" => Some(CanvasAction::DeleteNode),
+            _ => None,
+        },
+        crate::pinstar::state::PinstarMenuType::EdgeMenu => match item {
+            "Set Color..." => Some(CanvasAction::SetColor),
+            _ => None,
+        },
+        _ => None,
+    };
+    action.and_then(|a| {
+        let display = keybinds.canvas_keys_display(a);
+        let first = display.split('/').next().unwrap_or("").trim().to_string();
+        if first.is_empty() { None } else { Some(first) }
+    })
+}
+
 pub fn draw_pinstar_view(
     frame: &mut Frame,
     state: &mut PinstarState,
@@ -802,9 +832,12 @@ pub fn draw_pinstar_view(
         let menu_width = menu
             .items
             .iter()
-            .map(|s| s.len() as u16 + 4)
+            .map(|s| {
+                let shortcut = menu_shortcut(&state.keybinds, menu.menu_type, s);
+                s.len() + shortcut.map_or(0, |k| k.len() + 3) + 4
+            })
             .max()
-            .unwrap_or(25);
+            .unwrap_or(25) as u16;
         let menu_height = menu.items.len() as u16;
         let menu_rect = Rect::new(
             area.x + menu.x.min(area.width.saturating_sub(menu_width)),
@@ -820,6 +853,12 @@ pub fn draw_pinstar_view(
             .iter()
             .enumerate()
             .map(|(i, item)| {
+                let shortcut = menu_shortcut(&state.keybinds, menu.menu_type, item);
+                let text = if let Some(k) = shortcut {
+                    format!("  {item}  [{k}]")
+                } else {
+                    format!("  {item}  ")
+                };
                 let style = if i == menu.selected {
                     Style::default()
                         .fg(theme.highlight_fg)
@@ -828,7 +867,7 @@ pub fn draw_pinstar_view(
                 } else {
                     Style::default().fg(theme.text)
                 };
-                ListItem::new(format!("  {item}  ")).style(style)
+                ListItem::new(text).style(style)
             })
             .collect();
 

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -829,7 +829,7 @@ pub fn draw_pinstar_view(
     crate::ui::draw_status_bar(frame, hint_area, theme, left_line, right_line);
 
     if let Some(menu) = &state.context_menu {
-        let menu_width = menu
+        let menu_width: usize = menu
             .items
             .iter()
             .map(|s| {
@@ -837,12 +837,12 @@ pub fn draw_pinstar_view(
                 s.len() + shortcut.map_or(0, |k| k.len() + 3) + 4
             })
             .max()
-            .unwrap_or(25) as u16;
+            .unwrap_or(25);
         let menu_height = menu.items.len() as u16;
         let menu_rect = Rect::new(
-            area.x + menu.x.min(area.width.saturating_sub(menu_width)),
+            area.x + menu.x.min(area.width.saturating_sub(menu_width as u16)),
             area.y + menu.y.min(area.height.saturating_sub(menu_height)),
-            menu_width,
+            menu_width as u16,
             menu_height,
         );
 
@@ -854,12 +854,8 @@ pub fn draw_pinstar_view(
             .enumerate()
             .map(|(i, item)| {
                 let shortcut = menu_shortcut(&state.keybinds, menu.menu_type, item);
-                let text = if let Some(k) = shortcut {
-                    format!("  {item}  [{k}]")
-                } else {
-                    format!("  {item}  ")
-                };
-                let style = if i == menu.selected {
+                let is_selected = i == menu.selected;
+                let base_style = if is_selected {
                     Style::default()
                         .fg(theme.highlight_fg)
                         .bg(theme.highlight_bg)
@@ -867,10 +863,34 @@ pub fn draw_pinstar_view(
                 } else {
                     Style::default().fg(theme.text)
                 };
-                ListItem::new(text).style(style)
+                let color_square = i < menu.color_hints.len() && menu.color_hints[i].is_some();
+                let label = format!("  {item}  ");
+                let hint_str = shortcut.as_ref().map(|k| format!("[{k}]"));
+                let hint_width = hint_str.as_ref().map_or(0, |h| h.len());
+                let padding = menu_width.saturating_sub(label.len() + hint_width);
+                let hint_style = Style::default().fg(theme.muted).bg(if is_selected {
+                    theme.highlight_bg
+                } else {
+                    Color::Reset
+                });
+                let mut spans: Vec<Span> = Vec::new();
+                if color_square {
+                    let sq_color = menu.color_hints[i].unwrap_or(Color::Reset);
+                    spans.push(Span::styled("  ", base_style));
+                    spans.push(Span::styled("■ ", base_style.fg(sq_color)));
+                    spans.push(Span::styled(format!("{item}  "), base_style));
+                } else {
+                    spans.push(Span::styled(label.clone(), base_style));
+                }
+                if padding > 0 {
+                    spans.push(Span::styled(" ".repeat(padding), base_style));
+                }
+                if let Some(h) = hint_str {
+                    spans.push(Span::styled(h, hint_style));
+                }
+                ListItem::new(Line::from(spans))
             })
             .collect();
-
         let list = List::new(items).block(
             Block::default()
                 .borders(Borders::NONE)

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -664,6 +664,7 @@ pub fn draw_pinstar_view(
         }
     }
     state.floating_editor_rect = None;
+    state.edge_overlay_rect = None;
 
     if let Some(editor) = &mut state.floating_editor
         && let Some(node_id) = &state.selected_node_id
@@ -734,6 +735,61 @@ pub fn draw_pinstar_view(
                     cell.set_bg(muted_accent);
                 }
             }
+        }
+    }
+
+    // Edge-list overlay: when a node is selected, list its connected edges
+    // (1..n with from->to) in a bottom-right legend panel for keyboard/mouse
+    // edge access.
+    if state.selected_node_id.is_some() {
+        let edges = state.selected_node_edges();
+        if !edges.is_empty() {
+            let max_len = edges
+                .iter()
+                .enumerate()
+                .map(|(i, e)| {
+                    format!("{} {} → {}", i + 1, e.from_node, e.to_node)
+                        .chars()
+                        .count()
+                })
+                .max()
+                .unwrap_or(0);
+            let overlay_width = (max_len + 4) as u16;
+            let overlay_height = (edges.len() + 2) as u16;
+            let overlay_rect = Rect::new(
+                canvas_area.x + canvas_area.width.saturating_sub(overlay_width),
+                canvas_area.y + canvas_area.height.saturating_sub(overlay_height),
+                overlay_width,
+                overlay_height,
+            );
+            let rows: Vec<ratatui::text::Line> = edges
+                .iter()
+                .enumerate()
+                .map(|(i, e)| {
+                    ratatui::text::Line::from(vec![
+                        Span::styled(
+                            format!("{} ", i + 1),
+                            Style::default()
+                                .fg(theme.accent)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(
+                            format!("{} → {}", e.from_node, e.to_node),
+                            Style::default().fg(theme.text),
+                        ),
+                    ])
+                })
+                .collect();
+            let overlay = Paragraph::new(rows).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" EDGES ")
+                    .border_style(Style::default().fg(theme.accent))
+                    .style(theme.bg_style()),
+            );
+            frame.render_widget(Clear, overlay_rect);
+            frame.render_widget(overlay, overlay_rect);
+            state.edge_overlay_rect = Some(overlay_rect);
         }
     }
 

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -62,6 +62,66 @@ fn get_node_color(color_code: Option<&str>, theme: &AppThemeColors) -> Color {
     }
 }
 
+fn get_edge_color(color: Option<&str>, selected: bool, theme: &AppThemeColors) -> Color {
+    if selected {
+        return theme.accent;
+    }
+    match color {
+        Some(s) if s.starts_with('#') && s.len() == 7 => {
+            let r = u8::from_str_radix(&s[1..3], 16).unwrap_or(0);
+            let g = u8::from_str_radix(&s[3..5], 16).unwrap_or(0);
+            let b = u8::from_str_radix(&s[5..7], 16).unwrap_or(0);
+            Color::Rgb(r, g, b)
+        }
+        _ => theme.muted,
+    }
+}
+
+fn draw_braille_segment(
+    buf: &mut ratatui::buffer::Buffer,
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    view_left: f64,
+    view_right: f64,
+    view_top: f64,
+    view_bottom: f64,
+    style: crate::pinstar::data::EdgeStyle,
+    color: Color,
+) {
+    let mut current_x = x1;
+    let mut current_y = y1;
+    let dist = ((x2 - x1).powi(2) + (y2 - y1).powi(2)).sqrt();
+    let steps = (dist * 4.0) as usize;
+    if steps == 0 {
+        return;
+    }
+    let ddx = (x2 - x1) / steps as f64;
+    let ddy = (y2 - y1) / steps as f64;
+    for step in 0..=steps {
+        let draw = match style {
+            crate::pinstar::data::EdgeStyle::Solid => true,
+            crate::pinstar::data::EdgeStyle::Dashed => step % 16 < 8,
+            crate::pinstar::data::EdgeStyle::Dotted => step % 8 == 0,
+        };
+        if draw
+            && current_x >= view_left
+            && current_x < view_right
+            && current_y >= view_top
+            && current_y < view_bottom
+        {
+            let cell_x = current_x as u16;
+            let cell_y = current_y as u16;
+            let dot_x = ((current_x - cell_x as f64) * 2.0) as u16;
+            let dot_y = ((current_y - cell_y as f64) * 4.0) as u16;
+            crate::ui::braille::set_braille_dot(buf, cell_x, cell_y, dot_x, dot_y, color);
+        }
+        current_x += ddx;
+        current_y += ddy;
+    }
+}
+
 pub fn draw_pinstar_view(
     frame: &mut Frame,
     state: &mut PinstarState,
@@ -372,96 +432,42 @@ pub fn draw_pinstar_view(
     }
 
     {
-        use std::collections::HashMap;
-        // Keys borrow state.data.nodes; map drops at end of this block,
-        // before the non-group pass takes &mut state.image_cache.
-        let id_index: HashMap<&str, usize> = state
-            .data
-            .nodes
-            .iter()
-            .enumerate()
-            .map(|(i, n)| (n.id(), i))
-            .collect();
-
         for edge in &state.data.edges {
-            let Some(&ia) = id_index.get(edge.from_node.as_str()) else {
+            let Some(seg) = state.get_edge_segments(edge) else {
                 continue;
             };
-            let Some(&ib) = id_index.get(edge.to_node.as_str()) else {
-                continue;
-            };
-            let pf = &proj[ia];
-            let pt = &proj[ib];
-
-            let (fx, fy, fw, fh) = (pf.pos.0, pf.pos.1, pf.size.0, pf.size.1);
-            let (tx, ty, tw, th) = (pt.pos.0, pt.pos.1, pt.size.0, pt.size.1);
-
-            let scx = fx + fw / 2.0;
-            let scy = fy + fh / 2.0;
-            let tcx = tx + tw / 2.0;
-            let tcy = ty + th / 2.0;
-            let dx = tcx - scx;
-            let dy = tcy - scy;
-
-            let (ax, ay) = if dx.abs() > dy.abs() {
-                if dx > 0.0 { (fx + fw, scy) } else { (fx, scy) }
-            } else if dy > 0.0 {
-                (scx, fy + fh)
-            } else {
-                (scx, fy)
-            };
-
-            let (bx, by) = if dx.abs() > dy.abs() {
-                if dx > 0.0 { (tx, tcy) } else { (tx + tw, tcy) }
-            } else if dy > 0.0 {
-                (tcx, ty)
-            } else {
-                (tcx, ty + th)
-            };
-
-            let sfx = (ax - vx) * z + origin_x;
-            let sfy = (ay - vy) * z + origin_y;
-            let stx = (bx - vx) * z + origin_x;
-            let sty = (by - vy) * z + origin_y;
-
-            // Cull edges whose screen bbox is entirely outside canvas
-            let min_x = sfx.min(stx);
-            let max_x = sfx.max(stx);
-            let min_y = sfy.min(sty);
-            let max_y = sfy.max(sty);
-            if max_x < view_left || min_x > view_right || max_y < view_top || min_y > view_bottom {
-                continue;
-            }
-
-            let mut current_x = sfx;
-            let mut current_y = sfy;
-            let dist = ((stx - sfx).powi(2) + (sty - sfy).powi(2)).sqrt();
-            let steps = (dist * 4.0) as usize;
-            if steps > 0 {
-                let ddx = (stx - sfx) / steps as f64;
-                let ddy = (sty - sfy) / steps as f64;
-                for _ in 0..=steps {
-                    if current_x >= view_left
-                        && current_x < view_right
-                        && current_y >= view_top
-                        && current_y < view_bottom
-                    {
-                        let cell_x = current_x as u16;
-                        let cell_y = current_y as u16;
-                        let dot_x = ((current_x - cell_x as f64) * 2.0) as u16;
-                        let dot_y = ((current_y - cell_y as f64) * 4.0) as u16;
-                        crate::ui::braille::set_braille_dot(
-                            frame.buffer_mut(),
-                            cell_x,
-                            cell_y,
-                            dot_x,
-                            dot_y,
-                            theme.muted,
-                        );
-                    }
-                    current_x += ddx;
-                    current_y += ddy;
+            let is_edge_selected = state.selected_edge_id.as_deref() == Some(edge.id.as_str());
+            let edge_color = get_edge_color(edge.color.as_deref(), is_edge_selected, theme);
+            for &(sx, sy, ex, ey) in seg.0.iter().take(seg.1) {
+                let sfx = (sx - vx) * z + origin_x;
+                let sfy = (sy - vy) * z + origin_y;
+                let stx = (ex - vx) * z + origin_x;
+                let sty = (ey - vy) * z + origin_y;
+                // Cull per segment
+                let min_x = sfx.min(stx);
+                let max_x = sfx.max(stx);
+                let min_y = sfy.min(sty);
+                let max_y = sfy.max(sty);
+                if max_x < view_left
+                    || min_x > view_right
+                    || max_y < view_top
+                    || min_y > view_bottom
+                {
+                    continue;
                 }
+                draw_braille_segment(
+                    frame.buffer_mut(),
+                    sfx,
+                    sfy,
+                    stx,
+                    sty,
+                    view_left,
+                    view_right,
+                    view_top,
+                    view_bottom,
+                    edge.style,
+                    edge_color,
+                );
             }
         }
     } // end edge-pass block

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -959,6 +959,7 @@ mod tests {
                         to_side: Some("left".to_string()),
                         label: None,
                         color: None,
+                        style: crate::pinstar::data::EdgeStyle::Solid,
                     })
                 })
             })

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -127,7 +127,7 @@ fn menu_shortcut(
     menu_type: crate::pinstar::state::PinstarMenuType,
     item: &str,
 ) -> Option<String> {
-    crate::pinstar::state::menu_item_shortcut_char(menu_type, item).map(|c| format!("[{c}]"))
+    crate::pinstar::state::menu_item_shortcut_char(menu_type, item).map(|c| format!("{c}"))
 }
 pub fn draw_pinstar_view(
     frame: &mut Frame,
@@ -852,7 +852,7 @@ pub fn draw_pinstar_view(
                 };
                 let color_square = i < menu.color_hints.len() && menu.color_hints[i].is_some();
                 let label = format!("  {item}  ");
-                let hint_str = shortcut.as_ref().map(|k| format!("[{k}]"));
+                let hint_str = shortcut.as_ref().map(|k| format!("{k}"));
                 let hint_width = hint_str.as_ref().map_or(0, |h| h.len());
                 let padding = menu_width.saturating_sub(label.len() + hint_width);
                 let hint_style = Style::default().fg(theme.muted).bg(if is_selected {

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -979,7 +979,15 @@ pub fn draw_pinstar_view(
                 let label = format!("  {item}  ");
                 let hint_str = shortcut.as_ref().map(|k| format!("{k} "));
                 let hint_width = hint_str.as_ref().map_or(0, |h| h.len());
-                let padding = menu_width.saturating_sub(label.len() + hint_width);
+                // Color-square rows render "  ■ {item}  " which is 2 chars
+                // wider than the plain label; account for that so the hint is
+                // not clipped off the menu's right edge.
+                let content_width = if color_square {
+                    item.len() + 6
+                } else {
+                    label.len()
+                };
+                let padding = menu_width.saturating_sub(content_width + hint_width);
                 let hint_style = Style::default().fg(theme.muted).bg(if is_selected {
                     theme.highlight_bg
                 } else {

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -91,6 +91,15 @@ fn edge_overlay_color(color: Option<&str>, theme: &AppThemeColors) -> Color {
     }
 }
 
+/// Dimmed variant of a color, so "(no title)" text stays muted but still
+/// hints at the edge's own color.
+fn muted_edge_color(color: Color) -> Color {
+    match color {
+        Color::Rgb(r, g, b) => Color::Rgb(r / 2, g / 2, b / 2),
+        _ => color,
+    }
+}
+
 /// A resolved row for the edge-list overlay.
 struct OverlayEdgeRow {
     index: usize,
@@ -825,7 +834,7 @@ pub fn draw_pinstar_view(
                                 .push(Span::styled(title.clone(), Style::default().fg(edge_color))),
                             None => spans.push(Span::styled(
                                 no_title.clone(),
-                                Style::default().fg(theme.muted),
+                                Style::default().fg(muted_edge_color(edge_color)),
                             )),
                         }
                         spans.push(Span::styled(" → ", Style::default().fg(theme.muted)));
@@ -834,7 +843,7 @@ pub fn draw_pinstar_view(
                                 .push(Span::styled(title.clone(), Style::default().fg(edge_color))),
                             None => spans.push(Span::styled(
                                 no_title.clone(),
-                                Style::default().fg(theme.muted),
+                                Style::default().fg(muted_edge_color(edge_color)),
                             )),
                         }
                         ratatui::text::Line::from(spans)

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -137,10 +137,9 @@ fn menu_shortcut(
             "Set Color..." => Some(CanvasAction::SetColor),
             "Delete All Connections" => Some(CanvasAction::DeleteAllConnections),
             "Delete Node" => Some(CanvasAction::DeleteNode),
-            _ => None,
-        },
-        crate::pinstar::state::PinstarMenuType::EdgeMenu => match item {
-            "Set Color..." => Some(CanvasAction::SetColor),
+            "Add Text Node" => Some(CanvasAction::AddTextNode),
+            "Add Group" => Some(CanvasAction::AddGroup),
+            "Add Image Node" => Some(CanvasAction::AddImageNode),
             _ => None,
         },
         _ => None,
@@ -306,31 +305,9 @@ pub fn draw_pinstar_view(
             cur_x += grid_step_x;
         }
     }
-
-    // Select-rect pass: drawn BEFORE group/node passes so subsequent clears paint over it
-    if state.mouse_selecting
-        && let (Some(s), Some(e)) = (state.select_rect_start, state.select_rect_end)
-    {
-        let (sx1, sy1) = ((s.0 - vx) * z + origin_x, (s.1 - vy) * z + origin_y);
-        let (sx2, sy2) = ((e.0 - vx) * z + origin_x, (e.1 - vy) * z + origin_y);
-        let (min_x, max_x) = if sx1 < sx2 { (sx1, sx2) } else { (sx2, sx1) };
-        let (min_y, max_y) = if sy1 < sy2 { (sy1, sy2) } else { (sy2, sy1) };
-        let rect = Rect::new(
-            min_x
-                .max(canvas_area.left() as f64)
-                .min(canvas_area.right() as f64) as u16,
-            min_y
-                .max(canvas_area.top() as f64)
-                .min(canvas_area.bottom() as f64) as u16,
-            ((max_x - min_x).max(1.0)) as u16,
-            ((max_y - min_y).max(1.0)) as u16,
-        );
-        frame.render_widget(Clear, rect);
-        frame.render_widget(
-            Paragraph::new("").style(Style::default().bg(theme.highlight_bg)),
-            rect,
-        );
-    }
+    // Select-rect pass: drawn AFTER group/node passes.
+    // Uses buffer-cell bg mutation to avoid destroying node/edge characters.
+    // Done later, after all rendering — see below.
 
     for (idx, p) in proj.iter().enumerate() {
         if !p.is_group {
@@ -747,6 +724,38 @@ pub fn draw_pinstar_view(
 
             frame.render_widget(Clear, editor_rect);
             frame.render_widget(&*editor, editor_rect);
+        }
+    }
+
+    // Select-rect overlay: drawn AFTER all nodes/edges/editor.
+    // Uses buffer-cell bg mutation so node characters stay visible.
+    if state.mouse_selecting
+        && let (Some(s), Some(e)) = (state.select_rect_start, state.select_rect_end)
+    {
+        let (sx1, sy1) = ((s.0 - vx) * z + origin_x, (s.1 - vy) * z + origin_y);
+        let (sx2, sy2) = ((e.0 - vx) * z + origin_x, (e.1 - vy) * z + origin_y);
+        let (min_x, max_x) = if sx1 < sx2 { (sx1, sx2) } else { (sx2, sx1) };
+        let (min_y, max_y) = if sy1 < sy2 { (sy1, sy2) } else { (sy2, sy1) };
+        let left = (min_x
+            .max(canvas_area.left() as f64)
+            .min(canvas_area.right() as f64)) as u16;
+        let top = (min_y
+            .max(canvas_area.top() as f64)
+            .min(canvas_area.bottom() as f64)) as u16;
+        let width = ((max_x - min_x).max(1.0)) as u16;
+        let height = ((max_y - min_y).max(1.0)) as u16;
+        // Muted accent: divide each channel by 4 for a dark translucent effect
+        let muted_accent = match theme.accent {
+            Color::Rgb(r, g, b) => Color::Rgb(r / 4, g / 4, b / 4),
+            _ => theme.highlight_bg,
+        };
+        let buf = frame.buffer_mut();
+        for row in top..(top + height).min(buf.area.height) {
+            for col in left..(left + width).min(buf.area.width) {
+                if let Some(cell) = buf.cell_mut((col, row)) {
+                    cell.set_bg(muted_accent);
+                }
+            }
         }
     }
 

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -76,7 +76,7 @@ fn get_edge_color(color: Option<&str>, selected: bool, theme: &AppThemeColors) -
         _ => theme.muted,
     }
 }
-
+#[allow(clippy::too_many_arguments)]
 fn draw_braille_segment(
     buf: &mut ratatui::buffer::Buffer,
     x1: f64,
@@ -308,28 +308,28 @@ pub fn draw_pinstar_view(
     }
 
     // Select-rect pass: drawn BEFORE group/node passes so subsequent clears paint over it
-    if state.mouse_selecting {
-        if let (Some(s), Some(e)) = (state.select_rect_start, state.select_rect_end) {
-            let (sx1, sy1) = ((s.0 - vx) * z + origin_x, (s.1 - vy) * z + origin_y);
-            let (sx2, sy2) = ((e.0 - vx) * z + origin_x, (e.1 - vy) * z + origin_y);
-            let (min_x, max_x) = if sx1 < sx2 { (sx1, sx2) } else { (sx2, sx1) };
-            let (min_y, max_y) = if sy1 < sy2 { (sy1, sy2) } else { (sy2, sy1) };
-            let rect = Rect::new(
-                min_x
-                    .max(canvas_area.left() as f64)
-                    .min(canvas_area.right() as f64) as u16,
-                min_y
-                    .max(canvas_area.top() as f64)
-                    .min(canvas_area.bottom() as f64) as u16,
-                ((max_x - min_x).max(1.0)) as u16,
-                ((max_y - min_y).max(1.0)) as u16,
-            );
-            frame.render_widget(Clear, rect);
-            frame.render_widget(
-                Paragraph::new("").style(Style::default().bg(theme.highlight_bg)),
-                rect,
-            );
-        }
+    if state.mouse_selecting
+        && let (Some(s), Some(e)) = (state.select_rect_start, state.select_rect_end)
+    {
+        let (sx1, sy1) = ((s.0 - vx) * z + origin_x, (s.1 - vy) * z + origin_y);
+        let (sx2, sy2) = ((e.0 - vx) * z + origin_x, (e.1 - vy) * z + origin_y);
+        let (min_x, max_x) = if sx1 < sx2 { (sx1, sx2) } else { (sx2, sx1) };
+        let (min_y, max_y) = if sy1 < sy2 { (sy1, sy2) } else { (sy2, sy1) };
+        let rect = Rect::new(
+            min_x
+                .max(canvas_area.left() as f64)
+                .min(canvas_area.right() as f64) as u16,
+            min_y
+                .max(canvas_area.top() as f64)
+                .min(canvas_area.bottom() as f64) as u16,
+            ((max_x - min_x).max(1.0)) as u16,
+            ((max_y - min_y).max(1.0)) as u16,
+        );
+        frame.render_widget(Clear, rect);
+        frame.render_widget(
+            Paragraph::new("").style(Style::default().bg(theme.highlight_bg)),
+            rect,
+        );
     }
 
     for (idx, p) in proj.iter().enumerate() {

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -217,6 +217,31 @@ pub fn draw_pinstar_view(
         }
     }
 
+    // Select-rect pass: drawn BEFORE group/node passes so subsequent clears paint over it
+    if state.mouse_selecting {
+        if let (Some(s), Some(e)) = (state.select_rect_start, state.select_rect_end) {
+            let (sx1, sy1) = ((s.0 - vx) * z + origin_x, (s.1 - vy) * z + origin_y);
+            let (sx2, sy2) = ((e.0 - vx) * z + origin_x, (e.1 - vy) * z + origin_y);
+            let (min_x, max_x) = if sx1 < sx2 { (sx1, sx2) } else { (sx2, sx1) };
+            let (min_y, max_y) = if sy1 < sy2 { (sy1, sy2) } else { (sy2, sy1) };
+            let rect = Rect::new(
+                min_x
+                    .max(canvas_area.left() as f64)
+                    .min(canvas_area.right() as f64) as u16,
+                min_y
+                    .max(canvas_area.top() as f64)
+                    .min(canvas_area.bottom() as f64) as u16,
+                ((max_x - min_x).max(1.0)) as u16,
+                ((max_y - min_y).max(1.0)) as u16,
+            );
+            frame.render_widget(Clear, rect);
+            frame.render_widget(
+                Paragraph::new("").style(Style::default().bg(theme.highlight_bg)),
+                rect,
+            );
+        }
+    }
+
     for (idx, p) in proj.iter().enumerate() {
         if !p.is_group {
             continue;
@@ -248,8 +273,9 @@ pub fn draw_pinstar_view(
             (bottom - top) as u16,
         );
 
-        let is_selected = state.selected_node_id.as_deref() == Some(g.id.as_str());
-        let is_editing = is_selected && state.floating_editor.is_some();
+        let is_primary = state.selected_node_id.as_deref() == Some(g.id.as_str());
+        let is_selected = is_primary || state.selected_node_ids.contains(g.id.as_str());
+        let is_editing = is_primary && state.floating_editor.is_some();
         let base_color = get_node_color(g.color.as_deref(), theme);
         let border_color = if is_editing { theme.accent } else { base_color };
 
@@ -469,8 +495,10 @@ pub fn draw_pinstar_view(
 
         frame.render_widget(Clear, node_rect);
 
-        let is_selected = state.selected_node_id.as_deref() == Some(node.id());
-        let is_editing = is_selected && state.floating_editor.is_some();
+        // Multi-select: check both single-selection and multi-selection
+        let is_primary = state.selected_node_id.as_deref() == Some(node.id());
+        let is_selected = is_primary || state.selected_node_ids.contains(node.id());
+        let is_editing = is_primary && state.floating_editor.is_some();
 
         let node_color_attr = match node {
             crate::pinstar::data::CanvasNode::Text(n) => n.color.as_deref(),

--- a/src/pinstar/render.rs
+++ b/src/pinstar/render.rs
@@ -743,22 +743,7 @@ pub fn draw_pinstar_view(
         total_area.width,
         1,
     );
-    let hint_line = if state.connection_source_id.is_some() {
-        Line::from(vec![Span::styled(
-            "CONNECTION MODE: Select target node with mouse or Enter",
-            Style::default().fg(theme.muted),
-        )])
-    } else if state.deleting_connection_source_id.is_some() {
-        Line::from(vec![Span::styled(
-            "DELETE CONNECTION MODE: Select target node to remove link",
-            Style::default().fg(theme.muted),
-        )])
-    } else if state.resizing_node_id.is_some() {
-        Line::from(vec![Span::styled(
-            "RESIZE MODE: Drag mouse to resize, Left-click to confirm",
-            Style::default().fg(theme.muted),
-        )])
-    } else if state.footer_hint.is_empty() {
+    let hint_line = if state.footer_hint.is_empty() {
         let hints_items = vec![
             (
                 format!(
@@ -821,7 +806,7 @@ pub fn draw_pinstar_view(
             .iter()
             .map(|s| {
                 let shortcut = menu_shortcut(&state.keybinds, menu.menu_type, s);
-                s.len() + shortcut.map_or(0, |k| k.len() + 3) + 4
+                s.len() + shortcut.map_or(0, |k| k.len() + 4) + 4
             })
             .max()
             .unwrap_or(25);
@@ -852,7 +837,7 @@ pub fn draw_pinstar_view(
                 };
                 let color_square = i < menu.color_hints.len() && menu.color_hints[i].is_some();
                 let label = format!("  {item}  ");
-                let hint_str = shortcut.as_ref().map(|k| format!("{k}"));
+                let hint_str = shortcut.as_ref().map(|k| format!("{k} "));
                 let hint_width = hint_str.as_ref().map_or(0, |h| h.len());
                 let padding = menu_width.saturating_sub(label.len() + hint_width);
                 let hint_style = Style::default().fg(theme.muted).bg(if is_selected {

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -10,6 +10,8 @@ pub struct PinstarState {
     pub viewport_y: f64,
     pub zoom: f64,
     pub selected_node_id: Option<String>,
+    pub selected_node_ids: std::collections::HashSet<String>,
+    pub selected_edge_id: Option<String>,
     pub floating_editor: Option<TextArea<'static>>,
     pub raw_editor: TextArea<'static>,
     pub editor_focus: bool,
@@ -41,6 +43,13 @@ pub struct PinstarState {
     pub image_decode_tx: Option<std::sync::mpsc::Sender<crate::image_render::worker::ImageJob>>,
     pub is_panning: bool,
     pub last_zoom_at: Option<std::time::Instant>,
+    pub undo_stack: Vec<PinstarSnapshot>,
+    pub redo_stack: Vec<PinstarSnapshot>,
+}
+
+#[derive(Clone)]
+pub struct PinstarSnapshot {
+    pub data: CanvasData,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,6 +87,8 @@ impl PinstarState {
             viewport_y: 0.0,
             zoom: 0.1,
             selected_node_id: None,
+            selected_node_ids: std::collections::HashSet::new(),
+            selected_edge_id: None,
             floating_editor: None,
             raw_editor: TextArea::from(content.lines().map(String::from).collect::<Vec<_>>()),
             editor_focus: false,
@@ -109,7 +120,47 @@ impl PinstarState {
             image_decode_tx: None,
             is_panning: false,
             last_zoom_at: None,
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         })
+    }
+
+    pub fn record_undo_state(&mut self) {
+        self.undo_stack.push(PinstarSnapshot {
+            data: self.data.clone(),
+        });
+        if self.undo_stack.len() > 20 {
+            self.undo_stack.remove(0);
+        }
+        self.redo_stack.clear();
+    }
+    pub fn undo(&mut self) -> Result<()> {
+        if let Some(snapshot) = self.undo_stack.pop() {
+            self.redo_stack.push(PinstarSnapshot {
+                data: self.data.clone(),
+            });
+            self.data = snapshot.data;
+            self.selected_node_id = None;
+            self.selected_node_ids.clear();
+            self.selected_edge_id = None;
+            self.save()?;
+            self.sync_to_raw_editor();
+        }
+        Ok(())
+    }
+    pub fn redo(&mut self) -> Result<()> {
+        if let Some(snapshot) = self.redo_stack.pop() {
+            self.undo_stack.push(PinstarSnapshot {
+                data: self.data.clone(),
+            });
+            self.data = snapshot.data;
+            self.selected_node_id = None;
+            self.selected_node_ids.clear();
+            self.selected_edge_id = None;
+            self.save()?;
+            self.sync_to_raw_editor();
+        }
+        Ok(())
     }
 
     pub fn save(&self) -> Result<()> {
@@ -138,6 +189,7 @@ impl PinstarState {
     pub fn sync_from_raw_editor(&mut self) -> Result<()> {
         let content = self.raw_editor.lines().join("\n");
         if let Ok(data) = serde_json::from_str::<CanvasData>(&content) {
+            self.record_undo_state();
             self.data = data;
             let _ = self.save();
             Ok(())
@@ -275,9 +327,15 @@ impl PinstarState {
     }
 
     pub fn toggle_editor(&mut self) {
-        if let Some(editor) = &self.floating_editor {
-            if let Some(node_id) = &self.selected_node_id {
-                let text = editor.lines().join("\n");
+        let editor_text = if let Some(editor) = &self.floating_editor {
+            Some(editor.lines().join("\n"))
+        } else {
+            None
+        };
+        if let Some(text) = editor_text {
+            if self.selected_node_id.is_some() {
+                self.record_undo_state();
+                let node_id = self.selected_node_id.as_ref().unwrap();
                 for node in &mut self.data.nodes {
                     if node.id() == node_id {
                         node.set_text(text);
@@ -328,7 +386,9 @@ impl PinstarState {
     }
 
     pub fn start_resize(&mut self) {
-        if let Some(id) = &self.selected_node_id {
+        let id = self.selected_node_id.clone();
+        if let Some(id) = id {
+            self.record_undo_state();
             self.resizing_node_id = Some(id.clone());
             self.context_menu = None;
         }
@@ -342,7 +402,9 @@ impl PinstarState {
     }
 
     pub fn rename_node(&mut self, new_title: String) {
-        if let Some(node_id) = &self.selected_node_id {
+        let node_id = self.selected_node_id.clone();
+        if let Some(node_id) = node_id {
+            self.record_undo_state();
             let trimmed = new_title.trim().to_string();
             let title = if trimmed.is_empty() {
                 None
@@ -362,7 +424,9 @@ impl PinstarState {
     }
 
     pub fn delete_node_connections(&mut self) {
-        if let Some(id) = &self.selected_node_id {
+        let id = self.selected_node_id.clone();
+        if let Some(id) = id {
+            self.record_undo_state();
             let id_clone = id.clone();
             self.data
                 .edges
@@ -372,7 +436,9 @@ impl PinstarState {
     }
 
     pub fn set_node_color(&mut self, color: Option<String>) {
-        if let Some(id) = &self.selected_node_id {
+        let id = self.selected_node_id.clone();
+        if let Some(id) = id {
+            self.record_undo_state();
             for node in &mut self.data.nodes {
                 if node.id() == id {
                     match node {
@@ -389,6 +455,7 @@ impl PinstarState {
     }
 
     pub fn add_text_node(&mut self, x: f64, y: f64) {
+        self.record_undo_state();
         let id = format!("node_{}", &uuid::Uuid::new_v4().to_string()[..8]);
         self.data.nodes.push(crate::pinstar::data::CanvasNode::Text(
             crate::pinstar::data::TextNode {
@@ -408,6 +475,7 @@ impl PinstarState {
     }
 
     pub fn add_group(&mut self, x: f64, y: f64) {
+        self.record_undo_state();
         let id = format!("group_{}", &uuid::Uuid::new_v4().to_string()[..8]);
         self.data.nodes.insert(
             0,
@@ -430,6 +498,7 @@ impl PinstarState {
             Ok(Some(p)) => p,
             _ => return,
         };
+        self.record_undo_state();
         let id = format!("node_{}", &uuid::Uuid::new_v4().to_string()[..8]);
         self.data.nodes.push(crate::pinstar::data::CanvasNode::File(
             crate::pinstar::data::FileNode {
@@ -460,6 +529,7 @@ impl PinstarState {
             && source_id != target_id
         {
             let edge_id = format!("edge_{source_id}_{target_id}");
+            self.record_undo_state();
             if !self
                 .data
                 .edges
@@ -485,6 +555,7 @@ impl PinstarState {
         if let Some(source_id) = self.deleting_connection_source_id.take()
             && source_id != target_id
         {
+            self.record_undo_state();
             self.data
                 .edges
                 .retain(|e| !(e.from_node == source_id && e.to_node == target_id));

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -825,9 +825,10 @@ impl PinstarState {
             && source_id != target_id
         {
             self.record_undo_state();
-            self.data
-                .edges
-                .retain(|e| !(e.from_node == source_id && e.to_node == target_id));
+            self.data.edges.retain(|e| {
+                !((e.from_node == source_id && e.to_node == target_id)
+                    || (e.from_node == target_id && e.to_node == source_id))
+            });
             let _ = self.save();
         }
     }
@@ -952,5 +953,55 @@ mod tests {
             state.context_menu.as_ref().map(|menu| menu.menu_type),
             Some(PinstarMenuType::Canvas)
         ));
+    }
+
+    #[test]
+    fn connection_flow_and_delete_both_ways() {
+        use crate::pinstar::data::{CanvasData, CanvasNode, TextNode};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.canvas");
+        let data = CanvasData {
+            nodes: vec![
+                CanvasNode::Text(TextNode {
+                    id: "a".into(),
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 50.0,
+                    text: "".into(),
+                    title: None,
+                    color: None,
+                }),
+                CanvasNode::Text(TextNode {
+                    id: "b".into(),
+                    x: 200.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 50.0,
+                    text: "".into(),
+                    title: None,
+                    color: None,
+                }),
+            ],
+            edges: vec![],
+        };
+        std::fs::write(&path, serde_json::to_string(&data).unwrap()).unwrap();
+        let mut s = PinstarState::load(
+            &path,
+            crate::keybinds::Keybinds::default(),
+            crate::keybinds::KeyMatcher::new(),
+        )
+        .unwrap();
+        s.selected_node_id = Some("a".into());
+        s.start_connection();
+        s.select_node_in_direction(1.0, 0.0);
+        assert_eq!(s.selected_node_id.as_deref(), Some("b"));
+        s.finish_connection("b");
+        assert_eq!(s.data.edges.len(), 1);
+        // delete both ways: source=b, target=a should remove a->b
+        s.selected_node_id = Some("b".into());
+        s.start_delete_connection();
+        s.finish_delete_connection("a");
+        assert_eq!(s.data.edges.len(), 0);
     }
 }

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -42,9 +42,13 @@ pub struct PinstarState {
     pub image_picker: Option<ratatui_image::picker::Picker>,
     pub image_decode_tx: Option<std::sync::mpsc::Sender<crate::image_render::worker::ImageJob>>,
     pub is_panning: bool,
-    pub last_zoom_at: Option<std::time::Instant>,
     pub undo_stack: Vec<PinstarSnapshot>,
     pub redo_stack: Vec<PinstarSnapshot>,
+    pub select_rect_start: Option<(f64, f64)>,
+    pub select_rect_end: Option<(f64, f64)>,
+    pub mouse_selecting: bool,
+    pub mouse_dragged: bool,
+    pub last_zoom_at: Option<std::time::Instant>,
 }
 
 #[derive(Clone)]
@@ -122,6 +126,10 @@ impl PinstarState {
             last_zoom_at: None,
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
+            select_rect_start: None,
+            select_rect_end: None,
+            mouse_selecting: false,
+            mouse_dragged: false,
         })
     }
 
@@ -161,6 +169,47 @@ impl PinstarState {
             self.sync_to_raw_editor();
         }
         Ok(())
+    }
+
+    pub fn all_selected_node_ids(&self) -> std::collections::HashSet<String> {
+        let mut ids = self.selected_node_ids.clone();
+        if let Some(id) = &self.selected_node_id {
+            ids.insert(id.clone());
+        }
+        ids
+    }
+    pub fn select_nodes_in_rect(&mut self, x1: f64, y1: f64, x2: f64, y2: f64) {
+        let (min_x, max_x) = if x1 < x2 { (x1, x2) } else { (x2, x1) };
+        let (min_y, max_y) = if y1 < y2 { (y1, y2) } else { (y2, y1) };
+        let ids: std::collections::HashSet<String> = self
+            .data
+            .nodes
+            .iter()
+            .filter(|n| {
+                let (nx, ny) = n.pos();
+                let (nw, nh) = n.size();
+                nx + nw > min_x && nx < max_x && ny + nh > min_y && ny < max_y
+            })
+            .map(|n| n.id().to_string())
+            .collect();
+        if !ids.is_empty() {
+            self.selected_node_id = Some(ids.iter().next().unwrap().clone());
+        }
+        self.selected_node_ids = ids;
+    }
+    pub fn delete_selected_node(&mut self) {
+        let ids = self.all_selected_node_ids();
+        if ids.is_empty() {
+            return;
+        }
+        self.record_undo_state();
+        self.data.nodes.retain(|n| !ids.contains(n.id()));
+        self.data
+            .edges
+            .retain(|e| !ids.contains(&e.from_node) && !ids.contains(&e.to_node));
+        self.selected_node_id = None;
+        self.selected_node_ids.clear();
+        let _ = self.save();
     }
 
     pub fn save(&self) -> Result<()> {
@@ -424,34 +473,34 @@ impl PinstarState {
     }
 
     pub fn delete_node_connections(&mut self) {
-        let id = self.selected_node_id.clone();
-        if let Some(id) = id {
-            self.record_undo_state();
-            let id_clone = id.clone();
-            self.data
-                .edges
-                .retain(|e| e.from_node != id_clone && e.to_node != id_clone);
-            let _ = self.save();
+        let ids = self.all_selected_node_ids();
+        if ids.is_empty() {
+            return;
         }
+        self.record_undo_state();
+        self.data
+            .edges
+            .retain(|e| !ids.contains(&e.from_node) && !ids.contains(&e.to_node));
+        let _ = self.save();
     }
 
     pub fn set_node_color(&mut self, color: Option<String>) {
-        let id = self.selected_node_id.clone();
-        if let Some(id) = id {
-            self.record_undo_state();
-            for node in &mut self.data.nodes {
-                if node.id() == id {
-                    match node {
-                        crate::pinstar::data::CanvasNode::Text(n) => n.color = color.clone(),
-                        crate::pinstar::data::CanvasNode::File(n) => n.color = color.clone(),
-                        crate::pinstar::data::CanvasNode::Link(n) => n.color = color.clone(),
-                        crate::pinstar::data::CanvasNode::Group(n) => n.color = color.clone(),
-                    }
-                    break;
+        let ids = self.all_selected_node_ids();
+        if ids.is_empty() {
+            return;
+        }
+        self.record_undo_state();
+        for node in &mut self.data.nodes {
+            if ids.contains(node.id()) {
+                match node {
+                    crate::pinstar::data::CanvasNode::Text(n) => n.color = color.clone(),
+                    crate::pinstar::data::CanvasNode::File(n) => n.color = color.clone(),
+                    crate::pinstar::data::CanvasNode::Link(n) => n.color = color.clone(),
+                    crate::pinstar::data::CanvasNode::Group(n) => n.color = color.clone(),
                 }
             }
-            let _ = self.save();
         }
+        let _ = self.save();
     }
 
     pub fn add_text_node(&mut self, x: f64, y: f64) {

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -200,7 +200,7 @@ impl PinstarState {
             .map(|n| n.id().to_string())
             .collect();
         if !ids.is_empty() {
-            self.selected_node_id = Some(ids.iter().next().unwrap().clone());
+            self.selected_node_id = Some(ids.iter().next().expect("non-empty ids").clone());
         }
         self.selected_node_ids = ids;
     }
@@ -540,7 +540,7 @@ impl PinstarState {
         if let Some(text) = editor_text {
             if self.selected_node_id.is_some() {
                 self.record_undo_state();
-                let node_id = self.selected_node_id.as_ref().unwrap();
+                let node_id = self.selected_node_id.as_ref().expect("checked is_some above");
                 for node in &mut self.data.nodes {
                     if node.id() == node_id {
                         node.set_text(text);

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -83,6 +83,50 @@ pub struct PinstarContextMenu {
     pub menu_type: PinstarMenuType,
 }
 
+/// Returns the single-letter keyboard shortcut for a context-menu item, if any.
+/// Single source of truth shared by render (hint display) and input (key matching).
+pub fn menu_item_shortcut_char(menu_type: PinstarMenuType, item: &str) -> Option<char> {
+    match menu_type {
+        PinstarMenuType::Canvas => match item {
+            "Create Connection" => Some('c'),
+            "Delete Connection" => Some('d'),
+            "Rename Node" => Some('r'),
+            "Resize Node" => Some('s'),
+            "Set Color..." => Some('o'),
+            "Delete All Connections" => Some('b'),
+            "Delete Node" => Some('x'),
+            "Add Text Node" => Some('t'),
+            "Add Group" => Some('g'),
+            "Add Image Node" => Some('m'),
+            _ => None,
+        },
+        PinstarMenuType::EdgeMenu => match item {
+            "Set Color..." => Some('o'),
+            "Set Style..." => Some('s'),
+            _ => None,
+        },
+        PinstarMenuType::ColorPicker | PinstarMenuType::EdgeColorPicker => match item {
+            "Default" => Some('d'),
+            "Red" => Some('r'),
+            "Orange" => Some('o'),
+            "Yellow" => Some('y'),
+            "Green" => Some('g'),
+            "Cyan" => Some('c'),
+            "Purple" => Some('p'),
+            "Blue" => Some('b'),
+            "Magenta" => Some('m'),
+            "White" => Some('w'),
+            _ => None,
+        },
+        PinstarMenuType::EdgeStylePicker => match item {
+            "Solid" => Some('s'),
+            "Dashed" => Some('d'),
+            "Dotted" => Some('t'),
+            _ => None,
+        },
+    }
+}
+
 impl PinstarState {
     pub fn load(
         path: &Path,

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -49,6 +49,7 @@ pub struct PinstarState {
     pub mouse_selecting: bool,
     pub mouse_dragged: bool,
     pub last_zoom_at: Option<std::time::Instant>,
+    pub orthogonal_connections: bool,
 }
 
 #[derive(Clone)]
@@ -56,16 +57,21 @@ pub struct PinstarSnapshot {
     pub data: CanvasData,
 }
 
+#[derive(Clone, Copy)]
+pub struct EdgeSegments(pub [(f64, f64, f64, f64); 3], pub usize);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum PinstarTextField {
     Raw,
     Floating,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PinstarMenuType {
     Canvas,
     ColorPicker,
+    EdgeMenu,
+    EdgeColorPicker,
+    EdgeStylePicker,
 }
 
 pub struct PinstarContextMenu {
@@ -130,6 +136,7 @@ impl PinstarState {
             select_rect_end: None,
             mouse_selecting: false,
             mouse_dragged: false,
+            orthogonal_connections: false,
         })
     }
 
@@ -210,6 +217,155 @@ impl PinstarState {
         self.selected_node_id = None;
         self.selected_node_ids.clear();
         let _ = self.save();
+    }
+
+    pub fn get_edge_segments(
+        &self,
+        edge: &crate::pinstar::data::CanvasEdge,
+    ) -> Option<EdgeSegments> {
+        let from_idx = self
+            .data
+            .nodes
+            .iter()
+            .position(|n| n.id() == edge.from_node)?;
+        let to_idx = self
+            .data
+            .nodes
+            .iter()
+            .position(|n| n.id() == edge.to_node)?;
+        let from = &self.data.nodes[from_idx];
+        let to = &self.data.nodes[to_idx];
+        let (fx, fy, fw, fh) = (from.pos().0, from.pos().1, from.size().0, from.size().1);
+        let (tx, ty, tw, th) = (to.pos().0, to.pos().1, to.size().0, to.size().1);
+        let scx = fx + fw / 2.0;
+        let scy = fy + fh / 2.0;
+        let tcx = tx + tw / 2.0;
+        let tcy = ty + th / 2.0;
+        let dx = tcx - scx;
+        let dy = tcy - scy;
+
+        let (ax, ay) = if dx.abs() > dy.abs() {
+            if dx > 0.0 { (fx + fw, scy) } else { (fx, scy) }
+        } else if dy > 0.0 {
+            (scx, fy + fh)
+        } else {
+            (scx, fy)
+        };
+        let (bx, by) = if dx.abs() > dy.abs() {
+            if dx > 0.0 { (tx, tcy) } else { (tx + tw, tcy) }
+        } else if dy > 0.0 {
+            (tcx, ty)
+        } else {
+            (tcx, ty + th)
+        };
+
+        let segs = if self.orthogonal_connections {
+            let is_horiz = dx.abs() > dy.abs();
+            if is_horiz {
+                let mid_x = (ax + bx) / 2.0;
+                [
+                    (ax, ay, mid_x, ay),
+                    (mid_x, ay, mid_x, by),
+                    (mid_x, by, bx, by),
+                ]
+            } else {
+                let mid_y = (ay + by) / 2.0;
+                [
+                    (ax, ay, ax, mid_y),
+                    (ax, mid_y, bx, mid_y),
+                    (bx, mid_y, bx, by),
+                ]
+            }
+        } else {
+            [(ax, ay, bx, by), (0.0, 0.0, 0.0, 0.0), (0.0, 0.0, 0.0, 0.0)]
+        };
+        let count = if self.orthogonal_connections { 3 } else { 1 };
+        Some(EdgeSegments(segs, count))
+    }
+
+    pub fn select_edge_at(&mut self, cx: f64, cy: f64) -> Option<String> {
+        let tolerance = 5.0 / self.zoom;
+        let mut best: Option<(String, f64)> = None;
+        for edge in &self.data.edges {
+            let Some(seg) = self.get_edge_segments(edge) else {
+                continue;
+            };
+            for &(sx, sy, ex, ey) in seg.0.iter().take(seg.1) {
+                let dx = ex - sx;
+                let dy = ey - sy;
+                let len_sq = dx * dx + dy * dy;
+                if len_sq == 0.0 {
+                    let dist = ((cx - sx).powi(2) + (cy - sy).powi(2)).sqrt();
+                    if dist < tolerance {
+                        match &best {
+                            Some((_, bd)) if dist >= *bd => {}
+                            _ => best = Some((edge.id.clone(), dist)),
+                        }
+                    }
+                    continue;
+                }
+                let t = ((cx - sx) * dx + (cy - sy) * dy) / len_sq;
+                let t_clamped = t.clamp(0.0, 1.0);
+                let px = sx + t_clamped * dx;
+                let py = sy + t_clamped * dy;
+                let dist = ((cx - px).powi(2) + (cy - py).powi(2)).sqrt();
+                if dist < tolerance {
+                    match &best {
+                        Some((_, bd)) if dist >= *bd => {}
+                        _ => best = Some((edge.id.clone(), dist)),
+                    }
+                }
+            }
+        }
+        if let Some((id, _)) = best {
+            self.selected_edge_id = Some(id.clone());
+            self.selected_node_id = None;
+            self.selected_node_ids.clear();
+            Some(id)
+        } else {
+            self.selected_edge_id = None;
+            None
+        }
+    }
+
+    pub fn set_edge_color(&mut self, color: Option<String>) {
+        if let Some(id) = &self.selected_edge_id {
+            let id = id.clone();
+            self.record_undo_state();
+            for edge in &mut self.data.edges {
+                if edge.id == id {
+                    edge.color = color;
+                    break;
+                }
+            }
+            let _ = self.save();
+            self.sync_to_raw_editor();
+        }
+    }
+
+    pub fn set_edge_style(&mut self, style: crate::pinstar::data::EdgeStyle) {
+        if let Some(id) = &self.selected_edge_id {
+            let id = id.clone();
+            self.record_undo_state();
+            for edge in &mut self.data.edges {
+                if edge.id == id {
+                    edge.style = style;
+                    break;
+                }
+            }
+            let _ = self.save();
+            self.sync_to_raw_editor();
+        }
+    }
+
+    pub fn open_edge_context_menu(&mut self, x: u16, y: u16) {
+        self.context_menu = Some(PinstarContextMenu {
+            x,
+            y,
+            selected: 0,
+            items: vec!["Set Color...".to_string(), "Set Style...".to_string()],
+            menu_type: PinstarMenuType::EdgeMenu,
+        });
     }
 
     pub fn save(&self) -> Result<()> {

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -32,6 +32,7 @@ pub struct PinstarState {
     pub(crate) mouse_selection: crate::text_edit::MouseTextSelection,
     pub(crate) text_selection_target: Option<PinstarTextField>,
     pub(crate) floating_editor_rect: Option<ratatui::layout::Rect>,
+    pub edge_overlay_rect: Option<ratatui::layout::Rect>,
     pub show_grid: bool,
     pub help_requested: bool,
     pub footer_hint: String,
@@ -165,6 +166,7 @@ impl PinstarState {
             mouse_selection: crate::text_edit::MouseTextSelection::default(),
             text_selection_target: None,
             floating_editor_rect: None,
+            edge_overlay_rect: None,
             help_requested: false,
             footer_hint: String::new(),
             keybinds,
@@ -426,6 +428,48 @@ impl PinstarState {
             menu_type: PinstarMenuType::EdgeMenu,
             color_hints: Vec::new(),
         });
+    }
+
+    /// Opens the edge context menu centered in the given view area.
+    pub fn open_edge_menu_centered(&mut self, area: ratatui::layout::Rect) {
+        let menu_x = (area.width / 2).saturating_sub(12);
+        let menu_y = area.height;
+        self.open_edge_context_menu(menu_x, menu_y);
+    }
+
+    /// Edges connected to the currently selected node, in stable storage
+    /// order. Used by the edge-list overlay and number-key selection.
+    pub fn selected_node_edges(&self) -> Vec<&crate::pinstar::data::CanvasEdge> {
+        let Some(node_id) = &self.selected_node_id else {
+            return Vec::new();
+        };
+        self.data
+            .edges
+            .iter()
+            .filter(|e| e.from_node == *node_id || e.to_node == *node_id)
+            .collect()
+    }
+
+    /// Selects the edge at the given 1-based index among the selected node's
+    /// connected edges (deselecting the node). Returns its id, or None if out
+    /// of range / no node selected.
+    pub fn select_edge_of_selected_node(&mut self, index: usize) -> Option<String> {
+        let edge_id = {
+            let edges = self.selected_node_edges();
+            if index >= 1 && index <= edges.len() {
+                Some(edges[index - 1].id.clone())
+            } else {
+                None
+            }
+        };
+        if let Some(edge_id) = edge_id {
+            self.selected_edge_id = Some(edge_id.clone());
+            self.selected_node_id = None;
+            self.selected_node_ids.clear();
+            Some(edge_id)
+        } else {
+            None
+        }
     }
 
     pub fn save(&self) -> Result<()> {
@@ -1003,5 +1047,86 @@ mod tests {
         s.start_delete_connection();
         s.finish_delete_connection("a");
         assert_eq!(s.data.edges.len(), 0);
+    }
+
+    #[test]
+    fn edge_overlay_lists_and_selects_connected_edges() {
+        use crate::pinstar::data::{CanvasData, CanvasEdge, CanvasNode, EdgeStyle, TextNode};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.canvas");
+        let data = CanvasData {
+            nodes: vec![
+                CanvasNode::Text(TextNode {
+                    id: "a".into(),
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 50.0,
+                    text: "".into(),
+                    title: None,
+                    color: None,
+                }),
+                CanvasNode::Text(TextNode {
+                    id: "b".into(),
+                    x: 200.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 50.0,
+                    text: "".into(),
+                    title: None,
+                    color: None,
+                }),
+                CanvasNode::Text(TextNode {
+                    id: "c".into(),
+                    x: 0.0,
+                    y: 200.0,
+                    width: 100.0,
+                    height: 50.0,
+                    text: "".into(),
+                    title: None,
+                    color: None,
+                }),
+            ],
+            edges: vec![
+                CanvasEdge {
+                    id: "e1".into(),
+                    from_node: "a".into(),
+                    from_side: None,
+                    to_node: "b".into(),
+                    to_side: None,
+                    label: None,
+                    color: None,
+                    style: EdgeStyle::Solid,
+                },
+                CanvasEdge {
+                    id: "e2".into(),
+                    from_node: "a".into(),
+                    from_side: None,
+                    to_node: "c".into(),
+                    to_side: None,
+                    label: None,
+                    color: None,
+                    style: EdgeStyle::Solid,
+                },
+            ],
+        };
+        std::fs::write(&path, serde_json::to_string(&data).unwrap()).unwrap();
+        let mut s = PinstarState::load(
+            &path,
+            crate::keybinds::Keybinds::default(),
+            crate::keybinds::KeyMatcher::new(),
+        )
+        .unwrap();
+        s.selected_node_id = Some("a".into());
+        let edges = s.selected_node_edges();
+        assert_eq!(edges.len(), 2);
+        assert_eq!(edges[0].id, "e1");
+        assert_eq!(edges[1].id, "e2");
+        assert_eq!(s.select_edge_of_selected_node(2).as_deref(), Some("e2"));
+        assert_eq!(s.selected_edge_id.as_deref(), Some("e2"));
+        assert_eq!(s.selected_node_id, None);
+        // out of range -> None
+        s.selected_node_id = Some("a".into());
+        assert_eq!(s.select_edge_of_selected_node(3), None);
     }
 }

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -79,6 +79,7 @@ pub struct PinstarContextMenu {
     pub y: u16,
     pub selected: usize,
     pub items: Vec<String>,
+    pub color_hints: Vec<Option<ratatui::style::Color>>,
     pub menu_type: PinstarMenuType,
 }
 
@@ -365,6 +366,7 @@ impl PinstarState {
             selected: 0,
             items: vec!["Set Color...".to_string(), "Set Style...".to_string()],
             menu_type: PinstarMenuType::EdgeMenu,
+            color_hints: Vec::new(),
         });
     }
 
@@ -540,7 +542,10 @@ impl PinstarState {
         if let Some(text) = editor_text {
             if self.selected_node_id.is_some() {
                 self.record_undo_state();
-                let node_id = self.selected_node_id.as_ref().expect("checked is_some above");
+                let node_id = self
+                    .selected_node_id
+                    .as_ref()
+                    .expect("checked is_some above");
                 for node in &mut self.data.nodes {
                     if node.id() == node_id {
                         node.set_text(text);
@@ -587,6 +592,7 @@ impl PinstarState {
             selected: 0,
             items,
             menu_type: PinstarMenuType::Canvas,
+            color_hints: Vec::new(),
         });
     }
 

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -828,31 +828,42 @@ impl PinstarState {
                     }
                 }
             }
+            // Also capture multi-selected nodes
+            for nid in &self.selected_node_ids {
+                self.drag_captured_nodes.insert(nid.clone());
+            }
+        } else {
+            // When no primary node but multi-selected nodes exist, capture all of them
+            for nid in &self.selected_node_ids {
+                self.drag_captured_nodes.insert(nid.clone());
+            }
         }
     }
-
     pub fn move_selected_node(&mut self, dx: f64, dy: f64) {
-        if let Some(id) = &self.selected_node_id {
-            for node in &mut self.data.nodes {
-                let nid = node.id();
-                if nid == id || self.drag_captured_nodes.contains(nid) {
-                    match node {
-                        crate::pinstar::data::CanvasNode::Text(n) => {
-                            n.x += dx;
-                            n.y += dy;
-                        }
-                        crate::pinstar::data::CanvasNode::File(n) => {
-                            n.x += dx;
-                            n.y += dy;
-                        }
-                        crate::pinstar::data::CanvasNode::Link(n) => {
-                            n.x += dx;
-                            n.y += dy;
-                        }
-                        crate::pinstar::data::CanvasNode::Group(n) => {
-                            n.x += dx;
-                            n.y += dy;
-                        }
+        let primary = self.selected_node_id.clone();
+        let captured = self.drag_captured_nodes.clone();
+        if primary.is_none() && captured.is_empty() {
+            return;
+        }
+        for node in &mut self.data.nodes {
+            let nid = node.id();
+            if primary.as_deref() == Some(nid) || captured.contains(nid) {
+                match node {
+                    crate::pinstar::data::CanvasNode::Text(n) => {
+                        n.x += dx;
+                        n.y += dy;
+                    }
+                    crate::pinstar::data::CanvasNode::File(n) => {
+                        n.x += dx;
+                        n.y += dy;
+                    }
+                    crate::pinstar::data::CanvasNode::Link(n) => {
+                        n.x += dx;
+                        n.y += dy;
+                    }
+                    crate::pinstar::data::CanvasNode::Group(n) => {
+                        n.x += dx;
+                        n.y += dy;
                     }
                 }
             }

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -474,6 +474,7 @@ impl PinstarState {
                     to_side: Some("left".to_string()),
                     label: None,
                     color: None,
+                    style: crate::pinstar::data::EdgeStyle::Solid,
                 });
                 let _ = self.save();
             }

--- a/src/pinstar/state.rs
+++ b/src/pinstar/state.rs
@@ -185,6 +185,20 @@ impl PinstarState {
         })
     }
 
+    /// Returns the header-bar status message for the active transient mode
+    /// (connection / delete-connection / resize), or None when idle.
+    pub fn active_mode_message(&self) -> Option<&'static str> {
+        if self.connection_source_id.is_some() {
+            Some("CONNECTION MODE: Select target node with mouse or Enter")
+        } else if self.deleting_connection_source_id.is_some() {
+            Some("DELETE CONNECTION MODE: Select target node to remove link")
+        } else if self.resizing_node_id.is_some() {
+            Some("RESIZE MODE: Drag mouse to resize, Left-click to confirm")
+        } else {
+            None
+        }
+    }
+
     pub fn record_undo_state(&mut self) {
         self.undo_stack.push(PinstarSnapshot {
             data: self.data.clone(),


### PR DESCRIPTION
This PR focuses on improvements for the pinstar(canvas) view.

## ADDED
- Orthogonal edge style which can be toggled with `Ctrl + o`
- Keyboard shortcuts for context menu items, pressing the shortcut even without the context menu is open does the action too.
- Color palette has been expanded from 6 to 10 colors.
- Undo with `Ctrl + z` that can undo up to 20 actions.
- Right click drag selection feature that allows you to select multiple nodes and do actions on them or move all of them together.
- New edge properties `edgeColor` and `edgeStyle`, you can now set different colors to edges and different styles to edges.
- Edge overlay at the bottom right lists the edges that are in/out the selected node with numbers for each edge, pressing the number will select that edge and spawn the context menu for the edge.

## CHANGED
- UI/UX improvements through the view, some examples are: "CONNECTION MODE" or "DELETE CONNECTION MODE" are now shown in the header bar for consistency, added shortcut hints in context menu items, fully keyboard only navigation and usage is mostly possible now with new shortcuts, behavior tricks and more.

## FIXED
- Delete connection action works both ways now.