### PR TITLE
fix(tui): don't push Kitty keyboard enhancement flags on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,11 @@ pub(crate) static FORCE_QUIT: AtomicBool = AtomicBool::new(false);
 use anyhow::{Context, Result};
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
-    KeyCode, KeyEventKind, KeyModifiers, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-    PushKeyboardEnhancementFlags,
+    KeyCode, KeyEventKind, KeyModifiers,
+};
+#[cfg(not(windows))]
+use crossterm::event::{
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -93,12 +96,13 @@ pub fn run() -> Result<()> {
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         disable_raw_mode().ok();
+        #[cfg(not(windows))]
+        let _ = execute!(io::stderr(), PopKeyboardEnhancementFlags);
         let _ = execute!(
             io::stderr(),
             LeaveAlternateScreen,
             DisableMouseCapture,
             DisableBracketedPaste,
-            PopKeyboardEnhancementFlags,
             crossterm::cursor::Show,
         );
         prev(panic_info);
@@ -976,6 +980,18 @@ impl TerminalGuard {
     fn enter(mouse_enabled: bool) -> Result<Self> {
         enable_raw_mode().context("failed to enable raw mode")?;
         let mut stdout = io::stdout();
+        #[cfg(windows)]
+        let entered = if mouse_enabled {
+            execute!(
+                stdout,
+                EnterAlternateScreen,
+                EnableMouseCapture,
+                EnableBracketedPaste
+            )
+        } else {
+            execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)
+        };
+        #[cfg(not(windows))]
         let entered = if mouse_enabled {
             execute!(
                 stdout,
@@ -993,6 +1009,14 @@ impl TerminalGuard {
             )
         };
         if let Err(e) = entered {
+            #[cfg(not(windows))]
+            let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+            let _ = execute!(
+                stdout,
+                LeaveAlternateScreen,
+                DisableMouseCapture,
+                DisableBracketedPaste
+            );
             disable_raw_mode().ok(); // guard won't be built; clean up raw mode ourselves
             return Err(e).context("failed to enter alternate screen");
         }
@@ -1003,12 +1027,13 @@ impl TerminalGuard {
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         disable_raw_mode().ok();
+        #[cfg(not(windows))]
+        let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
         let _ = execute!(
             io::stdout(),
             LeaveAlternateScreen,
             DisableMouseCapture,
             DisableBracketedPaste,
-            PopKeyboardEnhancementFlags,
             crossterm::cursor::Show,
         );
     }
@@ -1018,12 +1043,16 @@ impl Drop for TerminalGuard {
 /// Bypasses graceful shutdown, saves, and confirm dialogs.
 pub fn force_quit() -> ! {
     crossterm::terminal::disable_raw_mode().ok();
+    #[cfg(not(windows))]
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        crossterm::event::PopKeyboardEnhancementFlags
+    );
     let _ = crossterm::execute!(
         std::io::stdout(),
         crossterm::terminal::LeaveAlternateScreen,
         crossterm::event::DisableMouseCapture,
         crossterm::event::DisableBracketedPaste,
-        crossterm::event::PopKeyboardEnhancementFlags,
         crossterm::cursor::Show,
     );
     std::process::exit(130);


### PR DESCRIPTION
## Summary

Fixes a Windows TUI startup failure caused by unconditionally enabling crossterm's Kitty keyboard enhancement flags.

On Windows, crossterm 0.29 does not support `PushKeyboardEnhancementFlags` through the legacy Windows API. The unconditional command therefore caused terminal initialization to fail with:

`Keyboard progressive enhancement not implemented for the legacy Windows API.`

This prevented `clin-rs` from reaching the TUI.

## Changes

- Gate `PushKeyboardEnhancementFlags` and `PopKeyboardEnhancementFlags` behind `cfg(not(windows))`.
- Gate the associated `KeyboardEnhancementFlags` imports on non-Windows platforms.
- Move keyboard enhancement cleanup out of the main `execute!` restoration chains so a failure there cannot prevent subsequent terminal restoration.
- Restore the alternate screen, mouse capture, and bracketed paste state if terminal initialization fails partway through.
- Preserve Kitty keyboard enhancement behavior on supported non-Windows platforms.

## Verification

- `cargo check` — passed
- `cargo build` — passed
- `cargo fmt -- --check` — passed
- `cargo clippy` — passed with two pre-existing warnings in `src/config/mod.rs` and `src/paths.rs`, unrelated to this change
- `cargo test` — 450 passed / 5 failed; the same five failures reproduce against pristine upstream `bd10d52` and are unrelated Windows-environment failures involving path separators, file ACLs, and `git file://` URLs
- Windows live-console smoke test — passed; the TUI launches and remains running instead of aborting during terminal initialization

## Before

On Windows, startup aborted with:

`Error: failed to enter alternate screen`

caused by:

`Keyboard progressive enhancement not implemented for the legacy Windows API.`

## After

The Kitty keyboard enhancement commands are skipped on Windows, allowing terminal initialization to complete and the TUI to launch normally.